### PR TITLE
Update namespace for e2e test

### DIFF
--- a/docs/developer/developer.md
+++ b/docs/developer/developer.md
@@ -243,7 +243,7 @@ python3 setup.py install --force --user
 ```
 Then go to `test/e2e`. 
 
-Run `kubectl create namespace kfserving-ci-e2e-test`
+Run `kubectl create namespace kserve-ci-e2e-test`
 
 For KIND/minikube:
 
@@ -253,7 +253,7 @@ For KIND/minikube:
 
 Run `pytest > testresults.txt`
 
-Tests may not clean up. To re-run, first do `kubectl delete namespace kfserving-ci-e2e-test`, recreate namespace and run again.
+Tests may not clean up. To re-run, first do `kubectl delete namespace kserve-ci-e2e-test`, recreate namespace and run again.
 
 ## Iterating
 


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`kserve/website` GitHub repository](https://github.com/kserve/website).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/help/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/help/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the KServe blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, add the corresponding "cherrypick-0.X"
label to the original PR; for example, "cherrypick-0.12".
Best practice is to open a PR for the cherry-pick yourself after your original PR has been merged
into the main branch.
After the cherry-pick PR has merged, remove the cherry-pick label from the original PR.

For all resources for contributing to the KServe documentation, see the
[KServe contributor's guide](docs/help/contributor/mkdocs-contributor-guide.md).

 -->

This PR is to fix the below error when run e2e test
```
E           RuntimeError: Exception when calling CustomObjectsApi->create_namespaced_custom_object:                 (404)
E           Reason: Not Found
E           HTTP response headers: HTTPHeaderDict({'Cache-Control': 'no-cache, private', 'Content-Type': 'application/json', 'X-Kubernetes-Pf-Flowschema-Uid': 'c8822021-dcf7-41d6-b43a-fbe7950bf654', 'X-Kubernetes-Pf-Prioritylevel-Uid': '2705bb68-2b47-41d9-8107-6385fc6fe379', 'Date': 'Fri, 08 Oct 2021 18:01:08 GMT', 'Content-Length': '216'})
E           HTTP response body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"namespaces \"kserve-ci-e2e-test\" not found","reason":"NotFound","details":{"name":"kserve-ci-e2e-test","kind":"namespaces"},"code":404}
```

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Using updated namespace `kserve-ci-e2e-test` for e2e test.
