### PR TITLE
Add doc on STORAGE_URI env var

### DIFF
--- a/docs/modelserving/v1beta1/custom/custom_model/README.md
+++ b/docs/modelserving/v1beta1/custom/custom_model/README.md
@@ -121,7 +121,7 @@ kubectl apply -f custom.yaml
 $ inferenceservice.serving.kserve.io/custom-model created
 ```
 
-### Arguments and Environment Variables
+### Arguments
 You can supply additional command arguments on the container spec to configure the model server.
 
 - `--workers`: fork the specified number of model server workers(multi-processing), the default value is 1. If you start the server after model is loaded
@@ -130,6 +130,13 @@ class with replicas and in this case each model server is created as a python wo
 - `--http_port`: the http port model server is listening on, the default port is 8080 
 - `--max_buffer_size`: Max socker buffer size for tornado http client, the default limit is 10Mi.
 - `--max_asyncio_workers`: Max number of workers to spawn for python async io loop, by default it is `min(32,cpu.limit + 4)`
+
+### Environment Variables
+
+You can supply additional environment variables on the container spec.
+
+- `STORAGE_URI`: load a model from a storage system supported by KServe e.g. `pvc://` `s3://`. This acts the same as `storageUri` when using a built-in predictor.
+The data will be available at `/mnt/models` in the container. For example, the following `STORAGE_URI: "pvc://my_model/model.onnx"` will be accessible at `/mnt/models/model.onnx`
 
 ### Run a prediction
 The first step is to [determine the ingress IP and ports](../../../../get_started/first_isvc.md#3-determine-the-ingress-ip-and-ports) and set `INGRESS_HOST` and `INGRESS_PORT`


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`kserve/website` GitHub repository](https://github.com/kserve/website).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/help/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/help/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the KServe blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, add the corresponding "cherrypick-0.X"
label to the original PR; for example, "cherrypick-0.12".
Best practice is to open a PR for the cherry-pick yourself after your original PR has been merged
into the main branch.
After the cherry-pick PR has merged, remove the cherry-pick label from the original PR.

For all resources for contributing to the KServe documentation, see the
[KServe contributor's guide](docs/help/contributor/mkdocs-contributor-guide.md).

 -->

Document the  `STORAGE_URI`  environment variable

Fixes #41

