### PR TITLE
fix broken explainer links

### DIFF
--- a/overrides/home.html
+++ b/overrides/home.html
@@ -55,7 +55,7 @@
           production serving</b> for <b>production ML serving</b> including <b>prediction, pre/post processing, monitoring and
           explainability</b>.
         </li>
-     
+
         <li class="task-list-item">
           <input type="checkbox" checked disabled /><span class="task-list-indicator"></span><b>Advanced deployments</b> with
           <b>canary rollout, experiments, ensembles and transformers</b>.
@@ -127,7 +127,7 @@
           <div id="" class="org-card--front" aria-labelledby="org-card-heading">
 
             <div class="org-card--picture">
-              <a href="/modelserving/explainer/explainer/">
+              <a href="modelserving/explainer/explainer">
                 <img src="./images/Explaination.png" alt="explainer">
               </a>
 
@@ -136,7 +136,7 @@
             <div class="org-card--body">
               <div class="org-card--body-heading">
                 <h5 class="org-card--heading" id="org-card--heading">
-                  <a href="/modelserving/explainer/explainer/">Model Explainability</a>
+                  <a href="modelserving/explainer/explainer">Model Explainability</a>
                 </h5>
               </div>
               <div class="org-card--body-content">


### PR DESCRIPTION
Signed-off-by: ted chang <htchang@us.ibm.com>
## Proposed Changes
Fix 2 broken explainer url that link to 404 page not found.
