### PR TITLE
Fix navigation index

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,17 +17,18 @@ nav:
                   - Model Serving Data Plane: modelserving/data_plane.md
                   - V2 Inference Protocol: modelserving/inference_api.md
           - Single Model Serving:
-            - Overview: modelserving/v1beta1/serving_runtime.md
-            - Tensorflow: modelserving/v1beta1/tensorflow/README.md
-            - PyTorch: modelserving/v1beta1/torchserve/README.md
-            - Scikit-learn: modelserving/v1beta1/sklearn/v2/README.md
-            - XGBoost: modelserving/v1beta1/xgboost/README.md
-            - PMML: modelserving/v1beta1/pmml/README.md
-            - Spark: modelserving/v1beta1/spark/README.md
-            - Lightgbm: modelserving/v1beta1/lightgbm/README.md
-            - PaddleServer: modelserving/v1beta1/paddle/README.md
-            - Triton: modelserving/v1beta1/triton/torchscript/README.md
-            - How to write a custom predictor: modelserving/v1beta1/custom/custom_model/README.md
+              - Supported Model Frameworks/Formats:
+                - Overview: modelserving/v1beta1/serving_runtime.md
+                - Tensorflow: modelserving/v1beta1/tensorflow/README.md
+                - PyTorch: modelserving/v1beta1/torchserve/README.md
+                - Scikit-learn: modelserving/v1beta1/sklearn/v2/README.md
+                - XGBoost: modelserving/v1beta1/xgboost/README.md
+                - PMML: modelserving/v1beta1/pmml/README.md
+                - Spark: modelserving/v1beta1/spark/README.md
+                - Lightgbm: modelserving/v1beta1/lightgbm/README.md
+                - Paddle: modelserving/v1beta1/paddle/README.md
+                - Triton: modelserving/v1beta1/triton/torchscript/README.md
+              - How to write a custom predictor: modelserving/v1beta1/custom/custom_model/README.md
           - Multi Model Serving:
                 - Overview:
                   - The Scalability Problem: modelserving/mms/multi-model-serving.md
@@ -35,7 +36,7 @@ nav:
           - Transformers:
                 - Feast: modelserving/v1beta1/transformer/feast/README.md
                 - How to write a custom transformer: modelserving/v1beta1/transformer/torchserve_image_transformer/README.md
-          - Storage:
+          - Model Storage:
                 - Azure: modelserving/storage/azure/azure.md
                 - PVC: modelserving/storage/pvc/pvc.md
                 - S3: modelserving/storage/s3/s3.md
@@ -92,7 +93,6 @@ theme:
     - navigation.tabs
     - navigation.tracking
     - navigation.tabs.sticky
-    - navigation.indexes
     - navigation.top
 
 markdown_extensions:

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -3,7 +3,7 @@
 {% block announce %}
  <h1>
 
- In Construction | <b>KServe v0.7 is Released</b>, <a href="/latest/blog/articles/2021-10-11-KServe-0.7-release/">Read blog &gt;&gt;</a>
-    
+ In Construction | <b>KServe v0.7 is Released</b>, <a href="/website/blog/articles/2021-10-11-KServe-0.7-release/">Read blog &gt;&gt;</a>
+
  </h1>
 {% endblock %}


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`kserve/website` GitHub repository](https://github.com/kserve/website).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/help/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/help/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the KServe blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, add the corresponding "cherrypick-0.X"
label to the original PR; for example, "cherrypick-0.12".
Best practice is to open a PR for the cherry-pick yourself after your original PR has been merged
into the main branch.
After the cherry-pick PR has merged, remove the cherry-pick label from the original PR.

For all resources for contributing to the KServe documentation, see the
[KServe contributor's guide](docs/help/contributor/mkdocs-contributor-guide.md).

 -->

"Fixes #issue-number" or "Add description of the problem this PR solves"
Fixes the navigation index
