### PR TITLE
Update developer guide for go 1.17

### DIFF
--- a/docs/developer/developer.md
+++ b/docs/developer/developer.md
@@ -15,7 +15,7 @@ Before submitting a PR, see also [CONTRIBUTING.md](https://github.com/kserve/kse
 
 You must install these tools:
 
-1. [`go`](https://golang.org/doc/install): KServe controller is written in Go and requires Go 1.14.0+.
+1. [`go`](https://golang.org/doc/install): KServe controller is written in Go and requires Go 1.17.0+.
 1. [`git`](https://help.github.com/articles/set-up-git/): For source control.
 1. [`Go Module`](https://blog.golang.org/using-go-modules): Go's new dependency management system.
 1. [`ko`](https://github.com/google/ko):
@@ -224,19 +224,9 @@ To setup from local code, do:
  2. `make undeploy`
  3. `make deploy-dev`
 
-
-Install pytest and test deps:
-```
-pip3 install pytest==6.0.2 pytest-xdist pytest-rerunfailures
-pip3 install --upgrade pytest-tornasync
-pip3 install urllib3==1.24.2
-pip3 install --upgrade setuptools
-```
-
 Go to `python/kserve` and install kserve python sdk deps 
 ```
-pip3 install -r requirements.txt
-python3 setup.py install --force --user
+pip3 install -e .[test]
 ```
 Then go to `test/e2e`. 
 


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`kserve/website` GitHub repository](https://github.com/kserve/website).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/help/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/help/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the KServe blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, add the corresponding "cherrypick-0.X"
label to the original PR; for example, "cherrypick-0.12".
Best practice is to open a PR for the cherry-pick yourself after your original PR has been merged
into the main branch.
After the cherry-pick PR has merged, remove the cherry-pick label from the original PR.

For all resources for contributing to the KServe documentation, see the
[KServe contributor's guide](docs/help/contributor/mkdocs-contributor-guide.md).

 -->

"Fixes #issue-number" or "Add description of the problem this PR solves"

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Update go dependency to 1.17
- Update e2e test run instruction

