### PR TITLE
Update developer guide with proper URL and model name

### DIFF
--- a/docs/developer/developer.md
+++ b/docs/developer/developer.md
@@ -193,19 +193,19 @@ make deploy-dev-storageInitializer
 
 Run the following command to smoke test the deployment
 ```bash
-kubectl apply -f https://github.com/kserve/kserve/tree/master/docs/samples/v1beta1/tensorflow/tensorflow.yaml
+kubectl apply -f https://raw.githubusercontent.com/kserve/kserve/master/docs/samples/v1beta1/tensorflow/tensorflow.yaml
 ```
 
 You should see model serving deployment running under default or your specified namespace.
 
 ```kubectl
-$ kubectl get pods -n default -l serving.kserve.io/inferenceservice=flowers-sample
+$ kubectl get pods -n default -l serving.kserve.io/inferenceservice=flower-sample
 ```
 
 ==**Expected Output**==    
 ```
 NAME                                                      READY   STATUS    RESTARTS   AGE
-flowers-sample-default-htz8r-deployment-8fd979f9b-w2qbv   3/3     Running   0          10s
+flower-sample-default-htz8r-deployment-8fd979f9b-w2qbv   3/3     Running   0          10s
 ```
 ## Running unit/integration tests
 `kserver-controller-manager` has a few integration tests which requires mock apiserver


### PR DESCRIPTION
Update developer guide with proper URL and model name
1. change URL to raw
2. change model name to be consistent with kserve sample

Signed-off-by: Chin Huang <chhuang@us.ibm.com>

<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`kserve/website` GitHub repository](https://github.com/kserve/website).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/help/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/help/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the KServe blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, add the corresponding "cherrypick-0.X"
label to the original PR; for example, "cherrypick-0.12".
Best practice is to open a PR for the cherry-pick yourself after your original PR has been merged
into the main branch.
After the cherry-pick PR has merged, remove the cherry-pick label from the original PR.

For all resources for contributing to the KServe documentation, see the
[KServe contributor's guide](docs/help/contributor/mkdocs-contributor-guide.md).

 -->

"Fixes #issue-number" or "Add description of the problem this PR solves"

## Proposed Changes <!-- Describe the changes the PR makes. -->

-
-
-

