### PR TITLE
Update supported kube/istio/knative version

### DIFF
--- a/docs/admin/kubernetes_deployment.md
+++ b/docs/admin/kubernetes_deployment.md
@@ -1,16 +1,15 @@
 # Kubernetes Deployment Installation Guide
 KServe supports `RawDeployment` mode to enable `InferenceService` deployment with Kubernetes resources [`Deployment`](https://kubernetes.io/docs/concepts/workloads/controllers/deployment), [`Service`](https://kubernetes.io/docs/concepts/services-networking/service), [`Ingress`](https://kubernetes.io/docs/concepts/services-networking/ingress) and [`Horizontal Pod Autoscaler`](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale). Comparing to serverless deployment it unlocks Knative limitations such as mounting multiple volumes, on the other hand `Scale down and from Zero` is not supported in `RawDeployment` mode.
 
-Kubernetes 1.19 is the minimally required version and please check the following recommended Istio versions for the corresponding
+Kubernetes 1.20 is the minimally required version and please check the following recommended Istio versions for the corresponding
 Kubernetes version.
 
 ## Recommended Version Matrix
 | Kubernetes Version | Recommended Istio Version   |
 | :---------- | :------------ |
-| 1.19       | 1.9, 1.10, 1.11   |
 | 1.20       | 1.9, 1.10, 1.11   |
 | 1.21       | 1.10, 1.11   |
-| 1.22       | 1.11   |
+| 1.22       | 1.11, 1.12   |
 
 ## 1. Install Istio
 The minimally required Istio version is 1.9.5 and you can refer to the [Istio install guide](https://istio.io/latest/docs/setup/install).
@@ -32,7 +31,7 @@ The minimally required Cert Manager version is 1.3.0 and you can refer to [Cert 
 
 Download the KServe's install manifest yaml.
 ```bash
-wget https://github.com/kserve/kserve/releases/download/v0.7.0/kserve.yaml
+wget https://github.com/kserve/kserve/releases/download/v0.8.0/kserve.yaml
 ```
 Open the `kserve.yaml`, find the `ConfigMap` with name `inferenceservice-config` in the manifest and modify the `deploy` section:
 ```json
@@ -46,4 +45,4 @@ deploy:
 === "kubectl"
     ```bash
     kubectl apply -f kserve.yaml
-    ``` 
+    ```

--- a/docs/admin/serverless.md
+++ b/docs/admin/serverless.md
@@ -2,18 +2,15 @@
 KServe Serverless installation enables autoscaling based on request volume and supports scale down to and from zero. It also supports revision management
 and canary rollout based on revisions.
 
-Kubernetes 1.17 is the minimally required version and please check the following recommended Knative, Istio versions for the corresponding
+Kubernetes 1.20 is the minimally required version and please check the following recommended Knative, Istio versions for the corresponding
 Kubernetes version.
 
 ## Recommended Version Matrix
 | Kubernetes Version | Recommended Istio Version   | Recommended Knative Version  |
 | :---------- | :------------ | :------------|
-| 1.17       | 1.9  | 0.19, 0.20  |
-| 1.18       | 1.9, 1.10 | 0.21, 0.22 |
-| 1.19       | 1.9, 1.10, 1.11   | 0.23, 0.24 |
-| 1.20       | 1.9, 1.10, 1.11   | 0.24, 0.25  |
-| 1.21       | 1.10, 1.11   | 0.25, 0.26  |
-| 1.22       | 1.11   | 0.25, 0.26  |
+| 1.20       | 1.9, 1.10, 1.11   | 0.25, 0.26, 1.0  |
+| 1.21       | 1.10, 1.11   | 0.25, 0.26, 1.0  |
+| 1.22       | 1.11, 1.12   | 0.25, 0.26, 1.0  |
 
 ## 1. Install Istio
 Please refer to the [Istio install guide](https://knative.dev/docs/admin/install/installing-istio).
@@ -34,5 +31,5 @@ The minimally required Cert Manager version is 1.3.0 and you can refer to [Cert 
 ## 4. Install KServe
 === "kubectl"
     ```bash
-    kubectl apply -f https://github.com/kserve/kserve/releases/download/v0.7.0/kserve.yaml
+    kubectl apply -f https://github.com/kserve/kserve/releases/download/v0.8.0/kserve.yaml
     ```

--- a/docs/get_started/first_isvc.md
+++ b/docs/get_started/first_isvc.md
@@ -137,7 +137,7 @@ Once you've created your json test input file (named something like "iris-input.
 ### 5. Run Performance Test
 ```bash
 # use kubectl create instead of apply because the job template is using generateName which doesn't work with kubectl apply
-kubectl create -f https://raw.githubusercontent.com/kserve/kserve/release-0.7/docs/samples/v1beta1/sklearn/v1/perf.yaml -n kserve-test
+kubectl create -f https://raw.githubusercontent.com/kserve/kserve/release-0.8/docs/samples/v1beta1/sklearn/v1/perf.yaml -n kserve-test
 ```
 
 ==**Expected Outpout**==

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,8 +6,8 @@ nav:
     - Administration Guide:
           - Install KServe:
                 - Serverless installation: admin/serverless.md
-                - Kubernetes deployment installation: admin/kubernetes_deployment.md
                 - ModelMesh installation: admin/modelmesh.md
+                - Kubernetes deployment installation: admin/kubernetes_deployment.md
                 - Migrating from KFServing: admin/migration.md
     - User Guide:
           - Concepts:


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`kserve/website` GitHub repository](https://github.com/kserve/website).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/help/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/help/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the KServe blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, add the corresponding "cherrypick-0.X"
label to the original PR; for example, "cherrypick-0.12".
Best practice is to open a PR for the cherry-pick yourself after your original PR has been merged
into the main branch.
After the cherry-pick PR has merged, remove the cherry-pick label from the original PR.

For all resources for contributing to the KServe documentation, see the
[KServe contributor's guide](docs/help/contributor/mkdocs-contributor-guide.md).

 -->

"Fixes #issue-number" or "Add description of the problem this PR solves"

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Update supported kubernetes to minimally require 1.20 as other versions reach EOL, see https://endoflife.date/kubernetes
- Update  istio, knative version
- Update kserve install version to v0.8.0

