### PR TITLE
Fix the wrong anchors for the ingress IP and ports determination

### DIFF
--- a/docs/modelserving/autoscaling/autoscaling.md
+++ b/docs/modelserving/autoscaling/autoscaling.md
@@ -52,7 +52,7 @@ $ inferenceservice.serving.kserve.io/flowers-sample created
 
 ### Predict `InferenceService` with concurrent requests
 
-The first step is to [determine the ingress IP and ports](../../get_started/first_isvc.md#3-determine-the-ingress-ip-and-ports) and set `INGRESS_HOST` and `INGRESS_PORT`
+The first step is to [determine the ingress IP and ports](../../get_started/first_isvc.md#4-determine-the-ingress-ip-and-ports) and set `INGRESS_HOST` and `INGRESS_PORT`
 
 Send traffic in 30 seconds spurts maintaining 5 in-flight requests.
 
@@ -153,7 +153,7 @@ $ inferenceservice.serving.kserve.io/flowers-sample created
 
 ### Predict InferenceService with target QPS
 
-The first step is to [determine the ingress IP and ports](../../get_started/first_isvc.md#3-determine-the-ingress-ip-and-ports) and set `INGRESS_HOST` and `INGRESS_PORT`
+The first step is to [determine the ingress IP and ports](../../get_started/first_isvc.md#4-determine-the-ingress-ip-and-ports) and set `INGRESS_HOST` and `INGRESS_PORT`
 
 Send 30 seconds of traffic maintaining 50 qps.
 
@@ -279,7 +279,7 @@ kubectl apply -f autoscale-gpu.yaml
 
 ### Predict InferenceService with concurrent requests
 
-The first step is to [determine the ingress IP and ports](../../get_started/first_isvc.md#3-determine-the-ingress-ip-and-ports) and set `INGRESS_HOST` and `INGRESS_PORT`
+The first step is to [determine the ingress IP and ports](../../get_started/first_isvc.md#4-determine-the-ingress-ip-and-ports) and set `INGRESS_HOST` and `INGRESS_PORT`
 
 Send 30 seconds of traffic maintaining 5 in-flight requests.
 

--- a/docs/modelserving/batcher/batcher.md
+++ b/docs/modelserving/batcher/batcher.md
@@ -77,7 +77,7 @@ kubectl create -f pytorch-batcher.yaml
 ```
 
 We can now send requests to the pytorch model using hey.
-The first step is to [determine the ingress IP and ports](../../get_started/first_isvc.md#3-determine-the-ingress-ip-and-ports) and set `INGRESS_HOST` and `INGRESS_PORT`
+The first step is to [determine the ingress IP and ports](../../get_started/first_isvc.md#4-determine-the-ingress-ip-and-ports) and set `INGRESS_HOST` and `INGRESS_PORT`
 
 ```bash
 MODEL_NAME=torchserve

--- a/docs/modelserving/detect/aif/germancredit/README.md
+++ b/docs/modelserving/detect/aif/germancredit/README.md
@@ -36,7 +36,7 @@ service.serving.knative.dev/message-dumper created
 
 ## Run a prediction
 
-The first step is to [determine the ingress IP and ports](../../../../get_started/first_isvc.md#3-determine-the-ingress-ip-and-ports) and set `INGRESS_HOST` and `INGRESS_PORT`
+The first step is to [determine the ingress IP and ports](../../../../get_started/first_isvc.md#4-determine-the-ingress-ip-and-ports) and set `INGRESS_HOST` and `INGRESS_PORT`
 
 ```
 MODEL_NAME=german-credit

--- a/docs/modelserving/detect/art/mnist/README.md
+++ b/docs/modelserving/detect/art/mnist/README.md
@@ -18,7 +18,7 @@ artserver   http://artserver.somecluster/v1/models/artserver   True    100      
 ```
 
 ## Explanation
-The first step is to [determine the ingress IP and ports](../../../../get_started/first_isvc.md#3-determine-the-ingress-ip-and-ports) and set `INGRESS_HOST` and `INGRESS_PORT`
+The first step is to [determine the ingress IP and ports](../../../../get_started/first_isvc.md#4-determine-the-ingress-ip-and-ports) and set `INGRESS_HOST` and `INGRESS_PORT`
 
 ```
 MODEL_NAME=artserver

--- a/docs/modelserving/explainer/aix/mnist/aix.md
+++ b/docs/modelserving/explainer/aix/mnist/aix.md
@@ -43,7 +43,7 @@ aixserver   http://aixserver.somecluster/v1/models/aixserver   True    100      
 ```
 
 ## Run Explanation
-The first step is to [determine the ingress IP and ports](../../../../get_started/first_isvc.md#3-determine-the-ingress-ip-and-ports) and set `INGRESS_HOST` and `INGRESS_PORT`, the example code for model training and explainer client can be found [here](https://github.com/kserve/kserve/blob/master/docs/samples/explanation/aix/mnist).
+The first step is to [determine the ingress IP and ports](../../../../get_started/first_isvc.md#4-determine-the-ingress-ip-and-ports) and set `INGRESS_HOST` and `INGRESS_PORT`, the example code for model training and explainer client can be found [here](https://github.com/kserve/kserve/blob/master/docs/samples/explanation/aix/mnist).
 
 ```
 MODEL_NAME=aix-explainer

--- a/docs/modelserving/explainer/alibi/income/README.md
+++ b/docs/modelserving/explainer/alibi/income/README.md
@@ -47,7 +47,7 @@ Create the InferenceService with above yaml:
 kubectl create -f income.yaml
 ```
 
-The first step is to [determine the ingress IP and ports](../../../../get_started/first_isvc.md#3-determine-the-ingress-ip-and-ports) and set `INGRESS_HOST` and `INGRESS_PORT`
+The first step is to [determine the ingress IP and ports](../../../../get_started/first_isvc.md#4-determine-the-ingress-ip-and-ports) and set `INGRESS_HOST` and `INGRESS_PORT`
 ```
 MODEL_NAME=income
 SERVICE_HOSTNAME=$(kubectl get inferenceservice income -o jsonpath='{.status.url}' | cut -d "/" -f 3)

--- a/docs/modelserving/logger/logger.md
+++ b/docs/modelserving/logger/logger.md
@@ -70,7 +70,7 @@ Create a sklearn predictor with the logger which points at the message dumper ur
 kubectl create -f sklearn-basic-logger.yaml
 ```
 
-We can now send a request to the sklearn model. The first step is to [determine the ingress IP and ports](../../get_started/first_isvc.md#3-determine-the-ingress-ip-and-ports) and set `INGRESS_HOST` and `INGRESS_PORT`
+We can now send a request to the sklearn model. The first step is to [determine the ingress IP and ports](../../get_started/first_isvc.md#4-determine-the-ingress-ip-and-ports) and set `INGRESS_HOST` and `INGRESS_PORT`
 
 ```bash
 MODEL_NAME=sklearn-iris
@@ -276,7 +276,7 @@ Apply the `sklearn-knative-eventing.yaml`.
 kubectl create -f sklearn-knative-eventing.yaml
 ```
 
-We can now send a request to the sklearn model. The first step is to [determine the ingress IP and ports](../../get_started/first_isvc.md#3-determine-the-ingress-ip-and-ports) and set `INGRESS_HOST` and `INGRESS_PORT`
+We can now send a request to the sklearn model. The first step is to [determine the ingress IP and ports](../../get_started/first_isvc.md#4-determine-the-ingress-ip-and-ports) and set `INGRESS_HOST` and `INGRESS_PORT`
 
 ```bash
 MODEL_NAME=sklearn-iris

--- a/docs/modelserving/storage/azure/azure.md
+++ b/docs/modelserving/storage/azure/azure.md
@@ -100,7 +100,7 @@ kubectl apply -f sklearn-azure.yaml
 
 ## Run a prediction
 
-Now, the ingress can be accessed at `${INGRESS_HOST}:${INGRESS_PORT}` or follow [this instruction](../../../get_started/first_isvc.md#3-determine-the-ingress-ip-and-ports)
+Now, the ingress can be accessed at `${INGRESS_HOST}:${INGRESS_PORT}` or follow [this instruction](../../../get_started/first_isvc.md#4-determine-the-ingress-ip-and-ports)
 to find out the ingress IP and port.
 
 ```bash

--- a/docs/modelserving/storage/pvc/pvc.md
+++ b/docs/modelserving/storage/pvc/pvc.md
@@ -126,7 +126,7 @@ kubectl apply -f sklearn-pvc.yaml
 
 ## Run a prediction
 
-Now, the ingress can be accessed at `${INGRESS_HOST}:${INGRESS_PORT}` or follow [this instruction](../../../get_started/first_isvc.md#3-determine-the-ingress-ip-and-ports)
+Now, the ingress can be accessed at `${INGRESS_HOST}:${INGRESS_PORT}` or follow [this instruction](../../../get_started/first_isvc.md#4-determine-the-ingress-ip-and-ports)
 to find out the ingress IP and port.
 
 ```bash

--- a/docs/modelserving/storage/s3/s3.md
+++ b/docs/modelserving/storage/s3/s3.md
@@ -91,7 +91,7 @@ kubectl apply -f mnist-s3.yaml
 
 ## Run a prediction
 
-Now, the ingress can be accessed at `${INGRESS_HOST}:${INGRESS_PORT}` or follow [this instruction](../../../get_started/first_isvc.md#3-determine-the-ingress-ip-and-ports)
+Now, the ingress can be accessed at `${INGRESS_HOST}:${INGRESS_PORT}` or follow [this instruction](../../../get_started/first_isvc.md#4-determine-the-ingress-ip-and-ports)
 to find out the ingress IP and port.
 
 ```bash

--- a/docs/modelserving/storage/uri/uri.md
+++ b/docs/modelserving/storage/uri/uri.md
@@ -120,7 +120,7 @@ kubectl apply -f sklearn-from-uri.yaml
 
 ### Run a prediction
 
-Now, the ingress can be accessed at `${INGRESS_HOST}:${INGRESS_PORT}` or follow [this instruction](../../../get_started/first_isvc.md#3-determine-the-ingress-ip-and-ports) to find out the ingress IP and port.
+Now, the ingress can be accessed at `${INGRESS_HOST}:${INGRESS_PORT}` or follow [this instruction](../../../get_started/first_isvc.md#4-determine-the-ingress-ip-and-ports) to find out the ingress IP and port.
 
 An example payload below:
 ```json
@@ -248,7 +248,7 @@ kubectl apply -f tensorflow-from-uri-gzip.yaml
 
 ## Run a prediction
 
-Again, the ingress can be accessed at `${INGRESS_HOST}:${INGRESS_PORT}` or follow [this instruction](../../../get_started/first_isvc.md#3-determine-the-ingress-ip-and-ports) to find out the ingress IP and port.
+Again, the ingress can be accessed at `${INGRESS_HOST}:${INGRESS_PORT}` or follow [this instruction](../../../get_started/first_isvc.md#4-determine-the-ingress-ip-and-ports) to find out the ingress IP and port.
 
 An example payload below:
 ```json

--- a/docs/modelserving/v1beta1/custom/custom_model/README.md
+++ b/docs/modelserving/v1beta1/custom/custom_model/README.md
@@ -141,7 +141,7 @@ You can supply additional environment variables on the container spec.
 The data will be available at `/mnt/models` in the container. For example, the following `STORAGE_URI: "pvc://my_model/model.onnx"` will be accessible at `/mnt/models/model.onnx`
 
 ### Run a prediction
-The first step is to [determine the ingress IP and ports](../../../../get_started/first_isvc.md#3-determine-the-ingress-ip-and-ports) and set `INGRESS_HOST` and `INGRESS_PORT`
+The first step is to [determine the ingress IP and ports](../../../../get_started/first_isvc.md#4-determine-the-ingress-ip-and-ports) and set `INGRESS_HOST` and `INGRESS_PORT`
 
 ```
 MODEL_NAME=custom-model

--- a/docs/modelserving/v1beta1/lightgbm/README.md
+++ b/docs/modelserving/v1beta1/lightgbm/README.md
@@ -83,7 +83,7 @@ $ inferenceservice.serving.kserve.io/lightgbm-iris created
 ```
 
 ## Run a prediction
-The first step is to [determine the ingress IP and ports](../../../get_started/first_isvc.md#3-determine-the-ingress-ip-and-ports) and set `INGRESS_HOST` and `INGRESS_PORT`
+The first step is to [determine the ingress IP and ports](../../../get_started/first_isvc.md#4-determine-the-ingress-ip-and-ports) and set `INGRESS_HOST` and `INGRESS_PORT`
 
 ```
 MODEL_NAME=lightgbm-iris

--- a/docs/modelserving/v1beta1/paddle/README.md
+++ b/docs/modelserving/v1beta1/paddle/README.md
@@ -38,7 +38,7 @@ inferenceservice.serving.kserve.io/paddle-resnet50 created
 
 ## Run a Prediction
 
-The first step is to [determine the ingress IP and ports](../../../get_started/first_isvc.md#3-determine-the-ingress-ip-and-ports) and set `INGRESS_HOST` and `INGRESS_PORT`
+The first step is to [determine the ingress IP and ports](../../../get_started/first_isvc.md#4-determine-the-ingress-ip-and-ports) and set `INGRESS_HOST` and `INGRESS_PORT`
 
 ```bash
 MODEL_NAME=paddle-resnet50

--- a/docs/modelserving/v1beta1/pmml/README.md
+++ b/docs/modelserving/v1beta1/pmml/README.md
@@ -45,7 +45,7 @@ $ inferenceservice.serving.kserve.io/pmml-demo created
 
 
 ## Run a prediction
-The first step is to [determine the ingress IP and ports](../../../get_started/first_isvc/#3-determine-the-ingress-ip-and-ports) and set `INGRESS_HOST` and `INGRESS_PORT`
+The first step is to [determine the ingress IP and ports](../../../get_started/first_isvc/#4-determine-the-ingress-ip-and-ports) and set `INGRESS_HOST` and `INGRESS_PORT`
 
 ```
 MODEL_NAME=pmml-demo

--- a/docs/modelserving/v1beta1/sklearn/v2/README.md
+++ b/docs/modelserving/v1beta1/sklearn/v2/README.md
@@ -152,7 +152,7 @@ You can see an example payload below:
 ```
 
 Now, assuming that your ingress can be accessed at
-`${INGRESS_HOST}:${INGRESS_PORT}` or you can follow [this instruction](../../../../get_started/first_isvc.md#3-determine-the-ingress-ip-and-ports)
+`${INGRESS_HOST}:${INGRESS_PORT}` or you can follow [this instruction](../../../../get_started/first_isvc.md#4-determine-the-ingress-ip-and-ports)
 to find out your ingress IP and port.
 
 you can use `curl` to send the inference request as:

--- a/docs/modelserving/v1beta1/spark/README.md
+++ b/docs/modelserving/v1beta1/spark/README.md
@@ -84,7 +84,7 @@ inferenceservice.serving.kserve.io/spark-pmml condition met
 ```
 
 ### Run a prediction
-The first step is to [determine the ingress IP and ports](../../../get_started/first_isvc.md#3-determine-the-ingress-ip-and-ports) and set `INGRESS_HOST` and `INGRESS_PORT`
+The first step is to [determine the ingress IP and ports](../../../get_started/first_isvc.md#4-determine-the-ingress-ip-and-ports) and set `INGRESS_HOST` and `INGRESS_PORT`
 
 ```
 MODEL_NAME=spark-pmml

--- a/docs/modelserving/v1beta1/tensorflow/README.md
+++ b/docs/modelserving/v1beta1/tensorflow/README.md
@@ -53,7 +53,7 @@ flower-sample   http://flower-sample.default.example.com   True           100   
 ```
  
 ### Run a prediction
-The first step is to [determine the ingress IP and ports](../../../get_started/first_isvc.md#3-determine-the-ingress-ip-and-ports) and set `INGRESS_HOST` and `INGRESS_PORT`, the inference request input
+The first step is to [determine the ingress IP and ports](../../../get_started/first_isvc.md#4-determine-the-ingress-ip-and-ports) and set `INGRESS_HOST` and `INGRESS_PORT`, the inference request input
 file can be downloaded [here](./input.json).
 
 ```

--- a/docs/modelserving/v1beta1/torchserve/README.md
+++ b/docs/modelserving/v1beta1/torchserve/README.md
@@ -149,7 +149,7 @@ $inferenceservice.serving.kserve.io/torchserve created
 
 ### Model Inference
 
-The first step is to [determine the ingress IP and ports](../../../get_started/first_isvc.md#3-determine-the-ingress-ip-and-ports) and set `INGRESS_HOST` and `INGRESS_PORT`.
+The first step is to [determine the ingress IP and ports](../../../get_started/first_isvc.md#4-determine-the-ingress-ip-and-ports) and set `INGRESS_HOST` and `INGRESS_PORT`.
 
 ```bash
 MODEL_NAME=mnist
@@ -252,7 +252,7 @@ $inferenceservice.serving.kserve.io/torchserve-mnist-v2 created
 ```
 
 ### Model Inference
-The first step is to [determine the ingress IP and ports](../../../get_started/first_isvc.md#3-determine-the-ingress-ip-and-ports) and set `INGRESS_HOST` and `INGRESS_PORT`.
+The first step is to [determine the ingress IP and ports](../../../get_started/first_isvc.md#4-determine-the-ingress-ip-and-ports) and set `INGRESS_HOST` and `INGRESS_PORT`.
 
 ```bash
 MODEL_NAME=mnist

--- a/docs/modelserving/v1beta1/torchserve/bert/README.md
+++ b/docs/modelserving/v1beta1/torchserve/bert/README.md
@@ -31,7 +31,7 @@ $inferenceservice.serving.kserve.io/torchserve-bert created
 
 ## Run a prediction
 
-The first step is to [determine the ingress IP and ports](../../../../get_started/first_isvc.md#3-determine-the-ingress-ip-and-ports) and set `INGRESS_HOST` and `INGRESS_PORT`
+The first step is to [determine the ingress IP and ports](../../../../get_started/first_isvc.md#4-determine-the-ingress-ip-and-ports) and set `INGRESS_HOST` and `INGRESS_PORT`
 
 ```bash
 MODEL_NAME=torchserve-bert

--- a/docs/modelserving/v1beta1/torchserve/metrics/README.md
+++ b/docs/modelserving/v1beta1/torchserve/metrics/README.md
@@ -64,7 +64,7 @@ $inferenceservice.serving.kserve.io/torch-metrics created
 
 ## Run a prediction
 
-The first step is to [determine the ingress IP and ports](../../../../get_started/first_isvc.md#3-determine-the-ingress-ip-and-ports) and set `INGRESS_HOST` and `INGRESS_PORT`
+The first step is to [determine the ingress IP and ports](../../../../get_started/first_isvc.md#4-determine-the-ingress-ip-and-ports) and set `INGRESS_HOST` and `INGRESS_PORT`
 
 ```bash
 MODEL_NAME=mnist

--- a/docs/modelserving/v1beta1/transformer/feast/README.md
+++ b/docs/modelserving/v1beta1/transformer/feast/README.md
@@ -80,7 +80,7 @@ $ inferenceservice.serving.kserve.io/driver-transformer created
 ```
 
 ## Run a prediction
-The first step is to [determine the ingress IP and ports](../../../../get_started/first_isvc.md#3-determine-the-ingress-ip-and-ports
+The first step is to [determine the ingress IP and ports](../../../../get_started/first_isvc.md#4-determine-the-ingress-ip-and-ports
 ) and set `INGRESS_HOST` and `INGRESS_PORT`
 
 ```bash

--- a/docs/modelserving/v1beta1/transformer/torchserve_image_transformer/README.md
+++ b/docs/modelserving/v1beta1/transformer/torchserve_image_transformer/README.md
@@ -178,7 +178,7 @@ $ inferenceservice.serving.kserve.io/torchserve-transformer created
 ### Run a prediction
 First, download the request [input payload](./input.json).
 
-Then, [determine the ingress IP and ports](../../../../get_started/first_isvc.md#3-determine-the-ingress-ip-and-ports) and set `INGRESS_HOST` and `INGRESS_PORT`.
+Then, [determine the ingress IP and ports](../../../../get_started/first_isvc.md#4-determine-the-ingress-ip-and-ports) and set `INGRESS_HOST` and `INGRESS_PORT`.
 
 ```
 SERVICE_NAME=torch-transformer
@@ -260,7 +260,7 @@ $ inferenceservice.serving.kserve.io/torch-grpc-transformer created
 ### Run a prediction
 First, download the request [input payload](./image.json).
 
-Then, [determine the ingress IP and ports](../../../../get_started/first_isvc.md#3-determine-the-ingress-ip-and-ports) and set `INGRESS_HOST` and `INGRESS_PORT`
+Then, [determine the ingress IP and ports](../../../../get_started/first_isvc.md#4-determine-the-ingress-ip-and-ports) and set `INGRESS_HOST` and `INGRESS_PORT`
 
 ```
 SERVICE_NAME=torch-grpc-transformer

--- a/docs/modelserving/v1beta1/triton/bert/README.md
+++ b/docs/modelserving/v1beta1/triton/bert/README.md
@@ -153,7 +153,7 @@ bert-v2-predictor-default-plhgs     bert-v2-predictor-default     bert-v2-predic
 bert-v2-transformer-default-sd6nc   bert-v2-transformer-default   bert-v2-transformer-default-sd6nc   1            True  
 ```
 ## Run a Prediction
-The first step is to [determine the ingress IP and ports](../../../../get_started/first_isvc.md#3-determine-the-ingress-ip-and-ports) and set `INGRESS_HOST` and `INGRESS_PORT`
+The first step is to [determine the ingress IP and ports](../../../../get_started/first_isvc.md#4-determine-the-ingress-ip-and-ports) and set `INGRESS_HOST` and `INGRESS_PORT`
 
 Send a question request with following input, the transformer expects sending a list of `instances` or `inputs` and `preprocess` then converts
 the inputs to expected tensor sending to `Triton Inference Server`.

--- a/docs/modelserving/v1beta1/triton/torchscript/README.md
+++ b/docs/modelserving/v1beta1/triton/torchscript/README.md
@@ -139,7 +139,7 @@ $ inferenceservice.serving.kserve.io/torchscript-cifar10 created
 
 
 ### Run a prediction with curl
-The first step is to [determine the ingress IP and ports](https://kserve.github.io/website/get_started/first_isvc/#3-determine-the-ingress-ip-and-ports) and set `INGRESS_HOST` and `INGRESS_PORT`
+The first step is to [determine the ingress IP and ports](https://kserve.github.io/website/get_started/first_isvc/#4-determine-the-ingress-ip-and-ports) and set `INGRESS_HOST` and `INGRESS_PORT`
 
 The latest Triton Inference Server already switched to use KServe [prediction V2 protocol](https://github.com/kserve/kserve/tree/master/docs/predict-api/v2), so
 the input request needs to follow the V2 schema with the specified data type, shape.

--- a/docs/modelserving/v1beta1/xgboost/README.md
+++ b/docs/modelserving/v1beta1/xgboost/README.md
@@ -167,7 +167,7 @@ Now, assuming that our ingress can be accessed at
 `${INGRESS_HOST}:${INGRESS_PORT}`, we can use `curl` to send our inference
 request as:
 
-> You can follow [these instructions](../../../get_started/first_isvc.md#3-determine-the-ingress-ip-and-ports) to find
+> You can follow [these instructions](../../../get_started/first_isvc.md#4-determine-the-ingress-ip-and-ports) to find
 > out your ingress IP and port.
 
 ```bash


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`kserve/website` GitHub repository](https://github.com/kserve/website).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/help/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/help/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the KServe blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, add the corresponding "cherrypick-0.X"
label to the original PR; for example, "cherrypick-0.12".
Best practice is to open a PR for the cherry-pick yourself after your original PR has been merged
into the main branch.
After the cherry-pick PR has merged, remove the cherry-pick label from the original PR.

For all resources for contributing to the KServe documentation, see the
[KServe contributor's guide](docs/help/contributor/mkdocs-contributor-guide.md).

 -->

The serial number of `determine-the-ingress-ip-and-ports` in https://kserve.github.io/website/0.8/get_started/first_isvc/ changes from `3` to `4`

This PR fixes the anchors in every documents.
