### PR TITLE
Fix inferenceservice name and result in aix.md at aix-explainer mnist

### DIFF
--- a/docs/modelserving/explainer/aix/mnist/aix.md
+++ b/docs/modelserving/explainer/aix/mnist/aix.md
@@ -37,9 +37,10 @@ Then find the url.
 
 === "kubectl"
 ```bash
-kubectl get inferenceservice aixserver
-NAME         URL                                               READY   DEFAULT TRAFFIC   CANARY TRAFFIC   AGE
-aixserver   http://aixserver.somecluster/v1/models/aixserver   True    100                                40m
+kubectl get inferenceservice aix-explainer
+NAME            URL                                        READY   PREV   LATEST   PREVROLLEDOUTREVISION   LATESTREADYREVISION                     AGE
+aix-explainer   http://aix-explainer.default.example.com   True           100                              aix-explainer-predictor-default-00001   43m
+
 ```
 
 ## Run Explanation


### PR DESCRIPTION


<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`kserve/website` GitHub repository](https://github.com/kserve/website).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/help/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/help/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the KServe blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, add the corresponding "cherrypick-0.X"
label to the original PR; for example, "cherrypick-0.12".
Best practice is to open a PR for the cherry-pick yourself after your original PR has been merged
into the main branch.
After the cherry-pick PR has merged, remove the cherry-pick label from the original PR.

For all resources for contributing to the KServe documentation, see the
[KServe contributor's guide](docs/help/contributor/mkdocs-contributor-guide.md).

 -->

In https://kserve.github.io/website/0.8/modelserving/explainer/aix/mnist/aix/#create-the-inferenceservice-with-aix-explainer

## Proposed Changes <!-- Describe the changes the PR makes. -->
The error occurs at the command "kubectl get inferenceservice aixserver".
The reason is that in the above yaml file we call it "aix-explainer".
Thus, It is supposed to be "kubectl get inferenceservice aix-server".
