### PR TITLE
Fix inferenceservice name and result in aix-explainer mnist example

### DIFF
--- a/docs/modelserving/explainer/aix/mnist/aix.md
+++ b/docs/modelserving/explainer/aix/mnist/aix.md
@@ -37,9 +37,9 @@ Then find the url.
 
 === "kubectl"
 ```bash
-kubectl get inferenceservice aixserver
-NAME         URL                                               READY   DEFAULT TRAFFIC   CANARY TRAFFIC   AGE
-aixserver   http://aixserver.somecluster/v1/models/aixserver   True    100                                40m
+kubectl get inferenceservice aix-explainer
+NAME            URL                                        READY   PREV   LATEST   PREVROLLEDOUTREVISION   LATESTREADYREVISION                     AGE
+aix-explainer   http://aix-explainer.default.example.com   True           100                              aix-explainer-predictor-default-00001   43m
 ```
 
 ## Run Explanation


### PR DESCRIPTION
Signed-off-by: shawnL <shawnl@csie.io>

In https://kserve.github.io/website/0.8/modelserving/explainer/aix/mnist/aix/#create-the-inferenceservice-with-aix-explainer

## Proposed Changes <!-- Describe the changes the PR makes. -->

The error occurs at the command "kubectl get inferenceservice aixserver".
The reason is that in the above yaml file we call it aix-explainer.
Thus, It is supposed to be "kubectl get inferenceservice aix-server".

