### PR TITLE
Add maxBatchDelay argument to TorchServe config example

### DIFF
--- a/docs/modelserving/v1beta1/torchserve/README.md
+++ b/docs/modelserving/v1beta1/torchserve/README.md
@@ -49,7 +49,7 @@ job_queue_size=10
 enable_envvars_config=true
 install_py_dep_per_model=true
 model_store=/mnt/models/model-store
-model_snapshot={"name":"startup.cfg","modelCount":1,"models":{"mnist":{"1.0":{"defaultVersion":true,"marName":"mnist.mar","minWorkers":1,"maxWorkers":5,"batchSize":1,"responseTimeout":120}}}}
+model_snapshot={"name":"startup.cfg","modelCount":1,"models":{"mnist":{"1.0":{"defaultVersion":true,"marName":"mnist.mar","minWorkers":1,"maxWorkers":5,"batchSize":1,"maxBatchDelay":10,"responseTimeout":120}}}}
 ```  
 
 The KServe/TorchServe integration supports KServe v1/v2 REST protocol, in the `config.properties` we need to turn on the flag `enable_envvars_config` to enable setting the kserve envelop using environment variable.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -94,7 +94,7 @@ extra_css:
   - stylesheets/extra.css
 
 repo_url: https://github.com/kserve/website
-edit_uri: edit/mkdocs/docs
+edit_uri: edit/main/docs
 
 theme:
   name: material


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`kserve/website` GitHub repository](https://github.com/kserve/website).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/help/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/help/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the KServe blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, add the corresponding "cherrypick-0.X"
label to the original PR; for example, "cherrypick-0.12".
Best practice is to open a PR for the cherry-pick yourself after your original PR has been merged
into the main branch.
After the cherry-pick PR has merged, remove the cherry-pick label from the original PR.

For all resources for contributing to the KServe documentation, see the
[KServe contributor's guide](docs/help/contributor/mkdocs-contributor-guide.md).

 -->

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Add `maxBatchDelay: the maximum delay in msec of a batch of a model` to the TorchServe `config.properties` example. If that argument is missing the TorchServe stops right after the start.
- Fix the edit button in pages so it can actually direct to GitHub page to edit the docs


