### PR TITLE
Update v1beta1 API for modelStatus and scaling fields

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -321,6 +321,36 @@ int
 </tr>
 <tr>
 <td>
+<code>scaleTarget</code><br/>
+<em>
+int
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ScaleTarget specifies the integer target value of the metric type the Autoscaler watches for.
+concurrency and rps targets are supported by Knative Pod Autoscaler
+(<a href="https://knative.dev/docs/serving/autoscaling/autoscaling-targets/">https://knative.dev/docs/serving/autoscaling/autoscaling-targets/</a>).</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>scaleMetric</code><br/>
+<em>
+<a href="#serving.kserve.io/v1beta1.ScaleMetric">
+ScaleMetric
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ScaleMetric defines the scaling metric type watched by autoscaler
+possible values are concurrency, rps, cpu, memory. concurrency, rps are supported via
+Knative Pod Autoscaler(<a href="https://knative.dev/docs/serving/autoscaling/autoscaling-metrics">https://knative.dev/docs/serving/autoscaling/autoscaling-metrics</a>).</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>containerConcurrency</code><br/>
 <em>
 int64
@@ -480,8 +510,37 @@ knative.dev/pkg/apis.URL
 </td>
 <td>
 <em>(Optional)</em>
-<p>URL holds the url that will distribute traffic over the provided traffic targets.
+<p>URL holds the primary url that will distribute traffic over the provided traffic targets.
+This will be one the REST or gRPC endpoints that are available.
 It generally has the form http[s]://{route-name}.{route-namespace}.{cluster-level-suffix}</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>restUrl</code><br/>
+<em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis#URL">
+knative.dev/pkg/apis.URL
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>REST endpoint of the component if available.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>grpcUrl</code><br/>
+<em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis#URL">
+knative.dev/pkg/apis.URL
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>gRPC endpoint of the component if available.</p>
 </td>
 </tr>
 <tr>
@@ -740,6 +799,20 @@ Kubernetes core/v1.Container
 Each framework will have different defaults that are populated in the underlying container spec.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>storage</code><br/>
+<em>
+<a href="#serving.kserve.io/v1beta1.StorageSpec">
+StorageSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Storage Spec for model location</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="serving.kserve.io/v1beta1.ExplainerSpec">ExplainerSpec
@@ -888,6 +961,122 @@ ExplainerConfig
 </td>
 </tr>
 </tbody>
+</table>
+<h3 id="serving.kserve.io/v1beta1.FailureInfo">FailureInfo
+</h3>
+<p>
+(<em>Appears on:</em><a href="#serving.kserve.io/v1beta1.ModelStatus">ModelStatus</a>)
+</p>
+<div>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>location</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Name of component to which the failure relates (usually Pod name)</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>reason</code><br/>
+<em>
+<a href="#serving.kserve.io/v1beta1.FailureReason">
+FailureReason
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>High level class of failure</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>message</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Detailed error message</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>modelRevisionName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Internal Revision/ID of model, tied to specific Spec contents</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>time</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#time-v1-meta">
+Kubernetes meta/v1.Time
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Time failure occurred or was discovered</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="serving.kserve.io/v1beta1.FailureReason">FailureReason
+(<code>string</code> alias)</h3>
+<p>
+(<em>Appears on:</em><a href="#serving.kserve.io/v1beta1.FailureInfo">FailureInfo</a>)
+</p>
+<div>
+<p>FailureReason enum</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;InvalidPredictorSpec&#34;</p></td>
+<td><p>The current Predictor Spec is invalid or unsupported</p>
+</td>
+</tr><tr><td><p>&#34;ModelLoadFailed&#34;</p></td>
+<td><p>The model failed to load within a ServingRuntime container</p>
+</td>
+</tr><tr><td><p>&#34;NoSupportingRuntime&#34;</p></td>
+<td><p>There are no ServingRuntime which support the specified model type</p>
+</td>
+</tr><tr><td><p>&#34;RuntimeDisabled&#34;</p></td>
+<td><p>The ServingRuntime is disabled</p>
+</td>
+</tr><tr><td><p>&#34;RuntimeNotRecognized&#34;</p></td>
+<td><p>There is no ServingRuntime defined with the specified runtime name</p>
+</td>
+</tr><tr><td><p>&#34;RuntimeUnhealthy&#34;</p></td>
+<td><p>Corresponding ServingRuntime containers failed to start or are unhealthy</p>
+</td>
+</tr></tbody>
 </table>
 <h3 id="serving.kserve.io/v1beta1.InferenceService">InferenceService
 </h3>
@@ -1129,6 +1318,19 @@ map[kserve.io/v1beta1/pkg/apis/serving/v1beta1.ComponentType]kserve.io/v1beta1/p
 <p>Statuses for the components of the InferenceService</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>modelStatus</code><br/>
+<em>
+<a href="#serving.kserve.io/v1beta1.ModelStatus">
+ModelStatus
+</a>
+</em>
+</td>
+<td>
+<p>Model related statuses</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="serving.kserve.io/v1beta1.InferenceServicesConfig">InferenceServicesConfig
@@ -1246,6 +1448,36 @@ string
 <td>
 </td>
 </tr>
+<tr>
+<td>
+<code>ingressClassName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>domainTemplate</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>urlScheme</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="serving.kserve.io/v1beta1.LightGBMSpec">LightGBMSpec
@@ -1356,6 +1588,46 @@ Valid values are: <br />
 </td>
 </tr></tbody>
 </table>
+<h3 id="serving.kserve.io/v1beta1.ModelCopies">ModelCopies
+</h3>
+<p>
+(<em>Appears on:</em><a href="#serving.kserve.io/v1beta1.ModelStatus">ModelStatus</a>)
+</p>
+<div>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>failedCopies</code><br/>
+<em>
+int
+</em>
+</td>
+<td>
+<p>How many copies of this predictor&rsquo;s models failed to load recently</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>totalCopies</code><br/>
+<em>
+int
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Total number copies of this predictor&rsquo;s models that are currently loaded</p>
+</td>
+</tr>
+</tbody>
+</table>
 <h3 id="serving.kserve.io/v1beta1.ModelFormat">ModelFormat
 </h3>
 <p>
@@ -1394,6 +1666,48 @@ string
 <p>Version of the model format.
 Used in validating that a predictor is supported by a runtime.
 Can be &ldquo;major&rdquo;, &ldquo;major.minor&rdquo; or &ldquo;major.minor.patch&rdquo;.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="serving.kserve.io/v1beta1.ModelRevisionStates">ModelRevisionStates
+</h3>
+<p>
+(<em>Appears on:</em><a href="#serving.kserve.io/v1beta1.ModelStatus">ModelStatus</a>)
+</p>
+<div>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>activeModelState</code><br/>
+<em>
+<a href="#serving.kserve.io/v1beta1.ModelState">
+ModelState
+</a>
+</em>
+</td>
+<td>
+<p>High level state string: Pending, Standby, Loading, Loaded, FailedToLoad</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>targetModelState</code><br/>
+<em>
+<a href="#serving.kserve.io/v1beta1.ModelState">
+ModelState
+</a>
+</em>
+</td>
+<td>
 </td>
 </tr>
 </tbody>
@@ -1451,6 +1765,110 @@ PredictorExtensionSpec
 <p>
 (Members of <code>PredictorExtensionSpec</code> are embedded into this type.)
 </p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="serving.kserve.io/v1beta1.ModelState">ModelState
+(<code>string</code> alias)</h3>
+<p>
+(<em>Appears on:</em><a href="#serving.kserve.io/v1beta1.ModelRevisionStates">ModelRevisionStates</a>)
+</p>
+<div>
+<p>ModelState enum</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;FailedToLoad&#34;</p></td>
+<td><p>All copies of the model failed to load</p>
+</td>
+</tr><tr><td><p>&#34;Loaded&#34;</p></td>
+<td><p>At least one copy of the model is loaded</p>
+</td>
+</tr><tr><td><p>&#34;Loading&#34;</p></td>
+<td><p>Model is loading</p>
+</td>
+</tr><tr><td><p>&#34;Pending&#34;</p></td>
+<td><p>Model is not yet registered</p>
+</td>
+</tr><tr><td><p>&#34;Standby&#34;</p></td>
+<td><p>Model is available but not loaded (will load when used)</p>
+</td>
+</tr></tbody>
+</table>
+<h3 id="serving.kserve.io/v1beta1.ModelStatus">ModelStatus
+</h3>
+<p>
+(<em>Appears on:</em><a href="#serving.kserve.io/v1beta1.InferenceServiceStatus">InferenceServiceStatus</a>)
+</p>
+<div>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>transitionStatus</code><br/>
+<em>
+<a href="#serving.kserve.io/v1beta1.TransitionStatus">
+TransitionStatus
+</a>
+</em>
+</td>
+<td>
+<p>Whether the available predictor endpoints reflect the current Spec or is in transition</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>states</code><br/>
+<em>
+<a href="#serving.kserve.io/v1beta1.ModelRevisionStates">
+ModelRevisionStates
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>State information of the predictor&rsquo;s model.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>lastFailureInfo</code><br/>
+<em>
+<a href="#serving.kserve.io/v1beta1.FailureInfo">
+FailureInfo
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Details of last failure, when load of target model is failed or blocked.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>copies</code><br/>
+<em>
+<a href="#serving.kserve.io/v1beta1.ModelCopies">
+ModelCopies
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Model copy information of the predictor&rsquo;s model.</p>
 </td>
 </tr>
 </tbody>
@@ -2250,7 +2668,7 @@ github.com/kserve/kserve/pkg/constants.InferenceServiceProtocol
 </td>
 <td>
 <em>(Optional)</em>
-<p>Protocol version to use by the predictor (i.e. v1 or v2)</p>
+<p>Protocol version to use by the predictor (i.e. v1 or v2 or grpc-v1 or grpc-v2)</p>
 </td>
 </tr>
 <tr>
@@ -2269,6 +2687,20 @@ Kubernetes core/v1.Container
 <em>(Optional)</em>
 <p>Container enables overrides for the predictor.
 Each framework will have different defaults that are populated in the underlying container spec.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>storage</code><br/>
+<em>
+<a href="#serving.kserve.io/v1beta1.StorageSpec">
+StorageSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Storage Spec for model location</p>
 </td>
 </tr>
 </tbody>
@@ -2663,6 +3095,97 @@ PredictorExtensionSpec
 </tr>
 </tbody>
 </table>
+<h3 id="serving.kserve.io/v1beta1.ScaleMetric">ScaleMetric
+(<code>string</code> alias)</h3>
+<p>
+(<em>Appears on:</em><a href="#serving.kserve.io/v1beta1.ComponentExtensionSpec">ComponentExtensionSpec</a>)
+</p>
+<div>
+<p>ScaleMetric enum</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;cpu&#34;</p></td>
+<td></td>
+</tr><tr><td><p>&#34;concurrency&#34;</p></td>
+<td></td>
+</tr><tr><td><p>&#34;memory&#34;</p></td>
+<td></td>
+</tr><tr><td><p>&#34;rps&#34;</p></td>
+<td></td>
+</tr></tbody>
+</table>
+<h3 id="serving.kserve.io/v1beta1.StorageSpec">StorageSpec
+</h3>
+<p>
+(<em>Appears on:</em><a href="#serving.kserve.io/v1beta1.ExplainerExtensionSpec">ExplainerExtensionSpec</a>, <a href="#serving.kserve.io/v1beta1.PredictorExtensionSpec">PredictorExtensionSpec</a>)
+</p>
+<div>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>path</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The path to the model object in the storage. It cannot co-exist
+with the storageURI.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>schemaPath</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The path to the model schema file in the storage.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>parameters</code><br/>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Parameters to override the default storage credentials and config.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>key</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The Storage Key in the secret for this model.</p>
+</td>
+</tr>
+</tbody>
+</table>
 <h3 id="serving.kserve.io/v1beta1.TFServingSpec">TFServingSpec
 </h3>
 <p>
@@ -2853,6 +3376,35 @@ TransformerConfig
 </tr>
 </tbody>
 </table>
+<h3 id="serving.kserve.io/v1beta1.TransitionStatus">TransitionStatus
+(<code>string</code> alias)</h3>
+<p>
+(<em>Appears on:</em><a href="#serving.kserve.io/v1beta1.ModelStatus">ModelStatus</a>)
+</p>
+<div>
+<p>TransitionStatus enum</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;BlockedByFailedLoad&#34;</p></td>
+<td><p>Target model failed to load</p>
+</td>
+</tr><tr><td><p>&#34;InProgress&#34;</p></td>
+<td><p>Waiting for target model to reach state of active model</p>
+</td>
+</tr><tr><td><p>&#34;InvalidSpec&#34;</p></td>
+<td><p>Target predictor spec failed validation</p>
+</td>
+</tr><tr><td><p>&#34;UpToDate&#34;</p></td>
+<td><p>Predictor is up-to-date (reflects current spec)</p>
+</td>
+</tr></tbody>
+</table>
 <h3 id="serving.kserve.io/v1beta1.TritonSpec">TritonSpec
 </h3>
 <p>
@@ -2924,5 +3476,5 @@ PredictorExtensionSpec
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>ab2896d2</code>.
+on git commit <code>133ecebb</code>.
 </em></p>


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`kserve/website` GitHub repository](https://github.com/kserve/website).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/help/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/help/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the KServe blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, add the corresponding "cherrypick-0.X"
label to the original PR; for example, "cherrypick-0.12".
Best practice is to open a PR for the cherry-pick yourself after your original PR has been merged
into the main branch.
After the cherry-pick PR has merged, remove the cherry-pick label from the original PR.

For all resources for contributing to the KServe documentation, see the
[KServe contributor's guide](docs/help/contributor/mkdocs-contributor-guide.md).

 -->

"Fixes #issue-number" or "Add description of the problem this PR solves"

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Update API docs for Scaling fields 
- Update API docs for `ModelStatus`

