### PR TITLE
Fix lightGBM example for feature names

### DIFF
--- a/docs/modelserving/v1beta1/lightgbm/README.md
+++ b/docs/modelserving/v1beta1/lightgbm/README.md
@@ -15,7 +15,7 @@ BST_FILE = "model.bst"
 iris = load_iris()
 y = iris['target']
 X = iris['data']
-dtrain = lgb.Dataset(X, label=y)
+dtrain = lgb.Dataset(X, label=y, feature_names=iris['feature_names'])
 
 params = {
     'objective':'multiclass', 


### PR DESCRIPTION
Signed-off-by: Dan Sun <dsun20@bloomberg.net>

<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`kserve/website` GitHub repository](https://github.com/kserve/website).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/help/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/help/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the KServe blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, add the corresponding "cherrypick-0.X"
label to the original PR; for example, "cherrypick-0.12".
Best practice is to open a PR for the cherry-pick yourself after your original PR has been merged
into the main branch.
After the cherry-pick PR has merged, remove the cherry-pick label from the original PR.

For all resources for contributing to the KServe documentation, see the
[KServe contributor's guide](docs/help/contributor/mkdocs-contributor-guide.md).

 -->

Fixes #172

## Proposed Changes <!-- Describe the changes the PR makes. -->

- The provided model training example does not include the `feature_names`

