### PR TITLE
Fix outdated Trition Transformer code

### DIFF
--- a/docs/modelserving/v1beta1/triton/torchscript/README.md
+++ b/docs/modelserving/v1beta1/triton/torchscript/README.md
@@ -228,7 +228,7 @@ format to tensor format according to V2 prediction protocol, `postprocess` handl
 
 ### Implement pre/post processing functions
 
-```python
+```python title="image_transformer_v2.py"
 import kserve
 from typing import Dict
 from PIL import Image

--- a/docs/modelserving/v1beta1/triton/torchscript/README.md
+++ b/docs/modelserving/v1beta1/triton/torchscript/README.md
@@ -276,7 +276,7 @@ class ImageTransformerV2(kserve.Model):
         return {output["name"]: np.array(output["data"]).reshape(output["shape"]).tolist()
                 for output in results["outputs"]}
 ```
-Please find [the code example](https://github.com/kserve/kserve/tree/release-0.9/docs/samples/v1beta1/triton/torchscript/image_transformer_v2) and [Dockerfile](https://github.com/kserve/kserve/blob/release-0.8/docs/samples/v1beta1/triton/torchscript/transformer.Dockerfile).
+Please find [the code example](https://github.com/kserve/kserve/tree/release-0.9/docs/samples/v1beta1/triton/torchscript/image_transformer_v2) and [Dockerfile](https://github.com/kserve/kserve/blob/release-0.9/docs/samples/v1beta1/triton/torchscript/transformer.Dockerfile).
 
 ### Build Transformer docker image
 ```


### PR DESCRIPTION
Signed-off-by: Xin Fu <xfu83@bloomberg.net>

<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`kserve/website` GitHub repository](https://github.com/kserve/website).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/help/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/help/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the KServe blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, add the corresponding "cherrypick-0.X"
label to the original PR; for example, "cherrypick-0.12".
Best practice is to open a PR for the cherry-pick yourself after your original PR has been merged
into the main branch.
After the cherry-pick PR has merged, remove the cherry-pick label from the original PR.

For all resources for contributing to the KServe documentation, see the
[KServe contributor's guide](docs/help/contributor/mkdocs-contributor-guide.md).

 -->

The issue is that the code snippet in "Implement pre/post processing functions" section is outdated and missing the `protocol` override.

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Sync the code snippet with the [image_transformer_v2.py](https://github.com/kserve/kserve/blob/release-0.9/docs/samples/v1beta1/triton/torchscript/image_transformer_v2/image_transformer_v2.py)
- Bump the version number in link to point to release version 0.9