### PR TITLE
add kubecon eu presentation to presentations page

### DIFF
--- a/docs/community/presentations.md
+++ b/docs/community/presentations.md
@@ -23,3 +23,4 @@ This page contains a list of presentations and demos. If you'd like to add a pre
 | [KubeCon AI Days 2022: Enhancing the Performance Testing Process for gRPC Model Inferencing at Scale](https://www.youtube.com/watch?v=PYB5P82kQns) | Ted Chang, Paul Van Eck |
 | [KubeCon Edge Days 2022: Model Serving at the Edge Made Easier](https://www.youtube.com/watch?v=0BlK7PaLCFM) | Paul Van Eck |
 | [KnativeCon 2022: How We Built an ML inference Platform with Knative](https://www.youtube.com/watch?v=yuxC1UVU_ec) | Dan Sun |
+| [Kubecon EU 2022: Exploring ML Model Serving with KServe (with fun drawings)](https://www.youtube.com/watch?v=FX6naJLaq2Y) | Alexa Griffith |


### PR DESCRIPTION
Adding the presentation I gave at Kubecon EU 2022 to the list of presentations https://www.youtube.com/watch?v=FX6naJLaq2Y

Signed-off-by: Alexa Griffith  <agriffith96@gmail.com>

<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`kserve/website` GitHub repository](https://github.com/kserve/website).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/help/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/help/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the KServe blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, add the corresponding "cherrypick-0.X"
label to the original PR; for example, "cherrypick-0.12".
Best practice is to open a PR for the cherry-pick yourself after your original PR has been merged
into the main branch.
After the cherry-pick PR has merged, remove the cherry-pick label from the original PR.

For all resources for contributing to the KServe documentation, see the
[KServe contributor's guide](docs/help/contributor/mkdocs-contributor-guide.md).

 -->

"Fixes #issue-number" or "Add description of the problem this PR solves"

## Proposed Changes <!-- Describe the changes the PR makes. -->

-
-
-

