### PR TITLE
Add grpc example for lightgbm

### DIFF
--- a/docs/modelserving/v1beta1/lightgbm/README.md
+++ b/docs/modelserving/v1beta1/lightgbm/README.md
@@ -200,6 +200,7 @@ To deploy the LightGBM model with V2 inference protocol, you need to set the **`
           storageUri: "gs://kfserving-examples/models/lightgbm/v2/iris"
     ```
 
+Apply the InferenceService yaml to get the REST endpoint
 === "kubectl"
 
 ```bash
@@ -312,6 +313,7 @@ Create the inference service yaml and expose the gRPC port, currently only one p
             containerPort: 9000
     ```
 
+Apply the InferenceService yaml to get the gRPC endpoint
 === "kubectl"
 
 ```

--- a/docs/modelserving/v1beta1/lightgbm/README.md
+++ b/docs/modelserving/v1beta1/lightgbm/README.md
@@ -163,7 +163,7 @@ file, you should now be ready to start our server as:
 mlserver start .
 ```
 
-### Deploy with InferenceService
+### Deploy InferenceService with REST endpoint
 
 When you deploy your model with `InferenceService` KServe injects sensible defaults so that it runs out-of-the-box without any
 further configuration. However, you can still override these defaults by providing a `model-settings.json` file similar to your local one.
@@ -212,7 +212,7 @@ kubectl apply -f lightgbm-v2.yaml
 inferenceservice.serving.kserve.io/lightgbm-v2-iris created
 ```
 
-### Test the deployed model
+### Test the deployed model with curl
 
 You can now test your deployed model by sending a sample request.
 
@@ -267,6 +267,147 @@ curl -v \
       "parameters":null,
       "data":
         [8.796664107010673e-06,0.9992300031041593,0.0007612002317336916,4.974786820804187e-06,0.9999919650711493,3.0601420299625077e-06]
+    }
+  ]
+}
+```
+
+### Create the InferenceService with gRPC endpoint
+Create the inference service yaml and expose the gRPC port, currently only one port is allowed to expose either HTTP or gRPC port and by default HTTP port is exposed.
+
+=== "Old Schema"
+
+    ```yaml
+    apiVersion: "serving.kserve.io/v1beta1"
+    kind: "InferenceService"
+    metadata:
+      name: "lightgbm-v2-iris"
+    spec:
+      predictor:
+        lightgbm:
+          protocolVersion: v2
+          storageUri: "gs://kfserving-examples/models/lightgbm/v2/iris"
+          ports:
+          - name: h2c
+            protocol: TCP
+            containerPort: 9000
+    ```
+=== "New Schema"
+
+    ```yaml
+    apiVersion: "serving.kserve.io/v1beta1"
+    kind: "InferenceService"
+    metadata:
+      name: "lightgbm-v2-iris"
+    spec:
+      predictor:
+        model:
+          modelFormat:
+            name: lightgbm
+          protocolVersion: v2
+          storageUri: "gs://kfserving-examples/models/lightgbm/v2/iris"
+          ports:
+          - name: h2c
+            protocol: TCP
+            containerPort: 9000
+    ```
+
+=== "kubectl"
+
+```
+kubectl apply -f lightgbm-v2-grpc.yaml
+```
+
+### Test the deployed model with grpcurl
+
+After the gRPC `InferenceService` becomes ready, [grpcurl](https://github.com/fullstorydev/grpcurl), can be used to send gRPC requests to the `InferenceService`.
+
+```bash
+# download the proto file
+curl -O https://raw.githubusercontent.com/kserve/kserve/master/docs/predict-api/v2/grpc_predict_v2.proto
+
+INPUT_PATH=iris-input-v2-grpc.json
+PROTO_FILE=grpc_predict_v2.proto
+SERVICE_HOSTNAME=$(kubectl get inferenceservice lightgbm-v2-iris -o jsonpath='{.status.url}' | cut -d "/" -f 3)
+```
+
+The gRPC APIs follow the KServe [prediction V2 protocol](https://github.com/kserve/kserve/tree/master/docs/predict-api/v2).
+
+For example, `ServerReady` API can be used to check if the server is ready:
+
+```bash
+grpcurl \
+  -plaintext \
+  -proto ${PROTO_FILE} \
+  -authority ${SERVICE_HOSTNAME}" \
+  ${INGRESS_HOST}:${INGRESS_PORT} \
+  inference.GRPCInferenceService.ServerReady
+```
+
+Expected Output
+```json
+{
+  "ready": true
+}
+```
+
+`ModelInfer` API takes input following the `ModelInferRequest` schema defined in the `grpc_predict_v2.proto` file. Notice that the input file differs from that used in the previous `curl` example.
+
+```bash
+grpcurl \
+  -vv \
+  -plaintext \
+  -proto ${PROTO_FILE} \
+  -authority ${SERVICE_HOSTNAME} \
+  -d @ \
+  ${INGRESS_HOST}:${INGRESS_PORT} \
+  inference.GRPCInferenceService.ModelInfer \
+  <<< $(cat "$INPUT_PATH")
+```
+
+==** Expected Output **==
+
+```
+Resolved method descriptor:
+// The ModelInfer API performs inference using the specified model. Errors are
+// indicated by the google.rpc.Status returned for the request. The OK code
+// indicates success and other codes indicate failure.
+rpc ModelInfer ( .inference.ModelInferRequest ) returns ( .inference.ModelInferResponse );
+
+Request metadata to send:
+(empty)
+
+Response headers received:
+accept-encoding: identity,gzip
+content-type: application/grpc
+date: Sun, 25 Sep 2022 10:25:05 GMT
+grpc-accept-encoding: identity,deflate,gzip
+server: istio-envoy
+x-envoy-upstream-service-time: 99
+
+Estimated response size: 91 bytes
+
+Response contents:
+{
+  "modelName": "lightgbm-v2-iris",
+  "outputs": [
+    {
+      "name": "predict",
+      "datatype": "FP64",
+      "shape": [
+        "2",
+        "3"
+      ],
+      "contents": {
+        "fp64Contents": [
+          8.796664107010673e-06,
+          0.9992300031041593,
+          0.0007612002317336916,
+          4.974786820804187e-06,
+          0.9999919650711493,
+          3.0601420299625077e-06
+        ]
+      }
     }
   ]
 }

--- a/docs/modelserving/v1beta1/lightgbm/iris-input-v2-grpc.json
+++ b/docs/modelserving/v1beta1/lightgbm/iris-input-v2-grpc.json
@@ -1,0 +1,21 @@
+{
+  "model_name": "lightgbm-v2-iris",
+  "inputs": [
+    {
+      "name": "input-0",
+      "shape": [2, 4],
+      "datatype": "FP32",
+      "contents": { 
+        "fp32_contents": [
+           6.8, 
+           2.8, 
+           4.8, 
+           1.4,
+           6.0, 
+           3.4, 
+           4.5, 
+           1.6]
+      }
+    }
+  ]
+}

--- a/docs/modelserving/v1beta1/lightgbm/lightgbm-v2-grpc.yaml
+++ b/docs/modelserving/v1beta1/lightgbm/lightgbm-v2-grpc.yaml
@@ -1,0 +1,15 @@
+apiVersion: "serving.kserve.io/v1beta1"
+kind: "InferenceService"
+metadata:
+  name: "lightgbm-v2-iris"
+spec:
+  predictor:
+    model:
+      modelFormat:
+        name: lightgbm
+      protocolVersion: v2
+      storageUri: "gs://kfserving-examples/models/lightgbm/v2/iris"
+      ports:
+        - name: h2c
+          protocol: TCP
+          containerPort: 9000

--- a/docs/modelserving/v1beta1/triton/torchscript/README.md
+++ b/docs/modelserving/v1beta1/triton/torchscript/README.md
@@ -244,7 +244,7 @@ For example, `ServerReady` API can be used to check if the server is ready:
 grpcurl \
   -plaintext \
   -proto ${PROTO_FILE} \
-  -H "Host: ${SERVICE_HOSTNAME}" \
+  -authority ${SERVICE_HOSTNAME}" \
   ${INGRESS_HOST}:${INGRESS_PORT} \
   inference.GRPCInferenceService.ServerReady
 ```


### PR DESCRIPTION
Signed-off-by: Dan Sun <dsun20@bloomberg.net>

<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`kserve/website` GitHub repository](https://github.com/kserve/website).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/help/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/help/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the KServe blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, add the corresponding "cherrypick-0.X"
label to the original PR; for example, "cherrypick-0.12".
Best practice is to open a PR for the cherry-pick yourself after your original PR has been merged
into the main branch.
After the cherry-pick PR has merged, remove the cherry-pick label from the original PR.

For all resources for contributing to the KServe documentation, see the
[KServe contributor's guide](/docs/help/contributor/mkdocs-contributor-guide.md).

 -->

"Fixes #issue-number" or "Add description of the problem this PR solves"

## Proposed Changes <!-- Describe the changes the PR makes. -->

-  Add lightgbm example for creating gRPC inference service and test with grpccurl
-  Fix torchscript grpc example to use `-authority` flag

