### PR TITLE
Add AMD logo to home page

### DIFF
--- a/overrides/home.html
+++ b/overrides/home.html
@@ -231,6 +231,9 @@
           draggable="false" />
       </div>
       <div class="logo">
+        <img src="https://upload.wikimedia.org/wikipedia/commons/7/7c/AMD_Logo.svg" alt="Advanced Micro Devices, Inc." draggable="false" />
+      </div>
+      <div class="logo">
         <img src="https://upload.wikimedia.org/wikipedia/commons/9/99/Gojek_logo_2019.svg" alt="" draggable="false" />
       </div>
       <div class="logo">


### PR DESCRIPTION
## Proposed Changes

- Adds AMD logo to the adopters list on the home page

I'm not sure if there's an established order for the logos but feel free to move the logo or let me know if I should move it after another logo.