### PR TITLE
Adds swagger ui to website api reference

### DIFF
--- a/docs/reference/swagger-ui.md
+++ b/docs/reference/swagger-ui.md
@@ -1,0 +1,3 @@
+# Swagger ui for Data Plane API
+
+<swagger-ui src="https://raw.githubusercontent.com/kserve/kserve/master/docs/predict-api/v2/rest_predict_v2.yaml"/>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,6 +81,7 @@ nav:
                 - Canary Example: modelserving/v1beta1/rollout/canary-example.md
     - API Reference:
           - Control Plane API: reference/api.md
+          - Data Plane swagger-ui: reference/swagger-ui.md
           - Python Client SDK: sdk_docs/sdk_doc.md
     - Developer Guide:
           - How to contribute: developer/developer.md
@@ -150,6 +151,12 @@ plugins:
      version_selector: true
      css_dir: css
      javascript_dir: js
+  - swagger-ui-tag:
+        background: White
+        docExpansion: none
+        filter: ""
+        syntaxHighlightTheme: monokai
+        tryItOutEnabled: true
 
 extra:
   social:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ mkdocs-macros-plugin>=0.5
 mkdocs-awesome-pages-plugin>=2.5
 mkdocs-redirects>=1.0.3
 mike>=1.1.2
+mkdocs-swagger-ui-tag


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`kserve/website` GitHub repository](https://github.com/kserve/website).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/help/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/help/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the KServe blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, add the corresponding "cherrypick-0.X"
label to the original PR; for example, "cherrypick-0.12".
Best practice is to open a PR for the cherry-pick yourself after your original PR has been merged
into the main branch.
After the cherry-pick PR has merged, remove the cherry-pick label from the original PR.

For all resources for contributing to the KServe documentation, see the
[KServe contributor's guide](/docs/help/contributor/mkdocs-contributor-guide.md).

 -->
 Add swagger-ui within website for dataplane api using plugin

Fixes #212
-
-
-

