### PR TITLE
Improve model monitoring docs

### DIFF
--- a/docs/modelserving/detect/aif/germancredit/README.md
+++ b/docs/modelserving/detect/aif/germancredit/README.md
@@ -6,6 +6,8 @@ We will be using the German Credit dataset maintained by the [UC Irvine Machine 
 
 We would like to be able to check if these "protected classes" are being used in a model's predictions. In this example we will feed the model some predictions and calculate metrics based off of the predictions the model makes. We will be using KServe payload logging capability collect the metrics. These metrics will give insight as to whether or not the model is biased for or against any protected classes. In this example we will look at the bias our deployed model has on those of age > 25 vs. those of age <= 25 and see if creditors are treating either unfairly.
 
+Sample resources for deploying the example can be found [here](https://github.com/kserve/kserve/tree/master/docs/samples/explanation/aif/germancredit)
+
 ## Create the InferenceService
 
 Apply the CRD

--- a/docs/modelserving/detect/alibi_detect/alibi_detect.md
+++ b/docs/modelserving/detect/alibi_detect/alibi_detect.md
@@ -20,6 +20,6 @@ The notebook requires KNative Eventing >= 0.18.
 
 ## CIFAR10 Drift Detector
 
-A [CIFAR10](https://www.cs.toronto.edu/~kriz/cifar.html) Drift Detector. Run the [notebook demo](cifar10_drift.ipynb) to test.
+A [CIFAR10](https://www.cs.toronto.edu/~kriz/cifar.html) Drift Detector. Run the [notebook demo](https://github.com/kserve/kserve/blob/master/docs/samples/drift-detection/alibi-detect/cifar10/cifar10_drift.ipynb) to test.
 
 The notebook requires KNative Eventing >= 0.18.

--- a/docs/modelserving/detect/art/mnist/README.md
+++ b/docs/modelserving/detect/art/mnist/README.md
@@ -4,11 +4,13 @@ This is an example to show how adversarially modified inputs can trick models to
 
 We will be using the MNIST dataset which is a dataset of handwritten digits and find adversarial examples which will can make the model predict a classification incorrectly, thereby showing the vulnerability of the model against adversarial attacks.
 
+Sample resources for deploying the example can be found [here](https://github.com/kserve/kserve/tree/master/docs/samples/explanation/art/mnist)
+
 To deploy the inferenceservice with v1beta1 API
 
 `kubectl apply -f art.yaml`
 
-Then find the url.
+Then find the url
 
 `kubectl get inferenceservice`
 


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`kserve/website` GitHub repository](https://github.com/kserve/website).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/help/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/help/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the KServe blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, add the corresponding "cherrypick-0.X"
label to the original PR; for example, "cherrypick-0.12".
Best practice is to open a PR for the cherry-pick yourself after your original PR has been merged
into the main branch.
After the cherry-pick PR has merged, remove the cherry-pick label from the original PR.

For all resources for contributing to the KServe documentation, see the
[KServe contributor's guide](/docs/help/contributor/mkdocs-contributor-guide.md).

 -->
Fixes #217

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Fix the `notebook demo` link  for the `drift detection` example to redirect the user to the location of the file (https://github.com/kserve/kserve/tree/master/docs/samples/explanation/art/mnist) instead of downloading the file directly.
- Add a link that points to the location of the yaml/script files someone should apply to run the [Bias Detection](https://kserve.github.io/website/master/modelserving/detect/aif/germancredit/) example.
- Add a link that points to the location of the required yaml/script files someone should apply to run the [Adversarial Detection](https://kserve.github.io/website/master/modelserving/detect/art/mnist/) example.

