### PR TITLE
Fix old link in getting started page

### DIFF
--- a/docs/get_started/README.md
+++ b/docs/get_started/README.md
@@ -1,7 +1,7 @@
 # Getting Started with KServe
 ## Before you begin
 !!! warning
-    KServe Quickstart Environments are for experimentation use only. For production installation, see our [Administrator's Guide](../admin/serverless.md)
+    KServe Quickstart Environments are for experimentation use only. For production installation, see our [Administrator's Guide](../admin/serverless/serverless.md)
 
 Before you can get started with a KServe Quickstart deployment you must install kind and the Kubernetes CLI.
 


### PR DESCRIPTION

Fixes current link that points to an old artifact in the getting started guide page.

## Proposed Changes 

Updating link in get_started to point to proper url