### PR TITLE
Update adopters with Canonical's

### DIFF
--- a/docs/community/adopters.md
+++ b/docs/community/adopters.md
@@ -8,6 +8,7 @@ This page contains a list of organizations who are using KServe either in produc
 | [Amazon Web Services](https://aws.amazon.com/)                               | [Ellis Tarn](https://github.com/ellistarn)         |
 | [Bloomberg](https://www.bloomberg.com/)                                      | [Dan Sun](https://github.com/yuzisun)              |
 | [Cars24](https://www.cars24.com/)                                            | [Swapnesh Khare](https://github.com/swapkh91)      |
+| [Chamred Kubeflow from Canonical](https://charmed-kubeflow.io/)              | [Daniela Plasencia](https://github.com/dnplas)     |
 | [Cisco](https://www.cisco.com/)                                              | [Krishna Durai](https://github.com/krishnadurai)   |
 | [CoreWeave](https://coreweave.com/)                                          | [Peter Salanki](https://github.com/salanki)        |
 | [Gojek](https://www.gojek.com/)                                              | [Willem Pienaar](https://github.com/woop)          |


### PR DESCRIPTION
I am the MLOps Product Manager at Canonical, the publisher behind Ubuntu. We have been using KFServing and these days KServe for model inference.  With the release of 1.7 (Beta goes live on the 8th of March), it will be part of the default bundle. Until now, it could have been related manually.

We are packaging KServe as a charm, which is going to be published on https://charmhub.io/ 
Daniela Plasencia is part of our engineering team who mainly worked on the technical side of it. Repo for reference: https://github.com/canonical/kserve-operators

<!-- General PR guidelines:


For all resources for contributing to the KServe documentation, see the
[KServe contributor's guide](/docs/help/contributor/mkdocs-contributor-guide.md).



## Proposed Changes <!-- Describe the changes the PR makes. -->

-Added Charmed Kubeflow from Canonical, publisher behind Ubuntu, as an adaptor 


