### PR TITLE
Fix Knative min requirement

### DIFF
--- a/docs/admin/serverless/serverless.md
+++ b/docs/admin/serverless/serverless.md
@@ -8,10 +8,10 @@ Kubernetes version.
 ## Recommended Version Matrix
 | Kubernetes Version | Recommended Istio Version   | Recommended Knative Version  |
 | :---------- | :------------ | :------------|
-| 1.22       | 1.11, 1.12   | 0.25, 0.26, 1.0  |
-| 1.23       | 1.12, 1.13   | 1.0-1.4  |
-| 1.24       | 1.13, 1.14   | 1.0-1.4  |
-| 1.25       | 1.15, 1.16   | 1.5-1.8  |
+| 1.22       | 1.11, 1.12   | 1.4-1.7  |
+| 1.23       | 1.12, 1.13   | 1.4-1.8  |
+| 1.24       | 1.13, 1.14   | 1.4-1.9  |
+| 1.25       | 1.15, 1.16   | 1.4-1.9  |
 
 ## 1. Install Knative Serving
 Please refer to [Knative Serving install guide](https://knative.dev/docs/admin/install/serving/install-serving-with-yaml/).


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`kserve/website` GitHub repository](https://github.com/kserve/website).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/help/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/help/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the KServe blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, add the corresponding "cherrypick-0.X"
label to the original PR; for example, "cherrypick-0.12".
Best practice is to open a PR for the cherry-pick yourself after your original PR has been merged
into the main branch.
After the cherry-pick PR has merged, remove the cherry-pick label from the original PR.

For all resources for contributing to the KServe documentation, see the
[KServe contributor's guide](/docs/help/contributor/mkdocs-contributor-guide.md).

 -->

"Fixes #issue-number" or "Add description of the problem this PR solves"

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Fix knative min requirement for kserve 0.10 release, as [the change](https://github.com/kserve/kserve/blob/v0.10.1/pkg/controller/v1beta1/inferenceservice/reconcilers/knative/ksvc_reconciler.go#L77) in KServe 0.10 need at least Knative 1.1 with the [minReplica annotation kebab case support](https://github.com/knative/serving/commit/c7dcb1482752489f547baa92a329bce0f36a45ef).
-

