### PR TITLE
fix(docs): Update AIX example to use custom explainer spec

### DIFF
--- a/docs/modelserving/explainer/aix/mnist/aix-explainer.yaml
+++ b/docs/modelserving/explainer/aix/mnist/aix-explainer.yaml
@@ -15,10 +15,6 @@ spec:
     - name: explainer
       image: kserve/aix-explainer:v0.10.1
       args:
-      - --predictor_host
-      - aix-explainer-predictor-default.default.svc.cluster.local
-      - --http_port
-      - "8080"
       - --model_name
       - aix-explainer
       - --explainer_type

--- a/docs/modelserving/explainer/aix/mnist/aix-explainer.yaml
+++ b/docs/modelserving/explainer/aix/mnist/aix-explainer.yaml
@@ -11,9 +11,29 @@ spec:
       command: ["python", "-m", "rfserver", "--model_name", "aix-explainer"]
       imagePullPolicy: Always
   explainer:
-    aix:
-      type: LimeImages
-      config:
-        num_samples: "100"
-        top_labels: "10"
-        min_weight: "0.01"
+    containers:
+    - name: explainer
+      image: kserve/aix-explainer:v0.10.1
+      args:
+      - --predictor_host
+      - aix-explainer-predictor-default.default.svc.cluster.local
+      - --http_port
+      - "8080"
+      - --model_name
+      - aix-explainer
+      - --explainer_type
+      - LimeImages
+      - --num_samples
+      - "100"
+      - --top_labels
+      - "10"
+      - --min_weight
+      - "0.01"
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "1"
+          memory: 2Gi
+        requests:
+          cpu: "1"
+          memory: 2Gi


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`kserve/website` GitHub repository](https://github.com/kserve/website).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/help/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/help/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the KServe blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, add the corresponding "cherrypick-0.X"
label to the original PR; for example, "cherrypick-0.12".
Best practice is to open a PR for the cherry-pick yourself after your original PR has been merged
into the main branch.
After the cherry-pick PR has merged, remove the cherry-pick label from the original PR.

For all resources for contributing to the KServe documentation, see the
[KServe contributor's guide](/docs/help/contributor/mkdocs-contributor-guide.md).

 -->

Updating all AIX examples to use custom explainer spec as we are planning to remove the AIX API from KServe. All examples and commands work the same way except the core spec are now using custom explainer spec.
https://github.com/kserve/kserve/pull/2811

## Proposed Changes <!-- Describe the changes the PR makes. -->

-
-
-

