### PR TITLE
fix wrong model name in batcher example

### DIFF
--- a/docs/modelserving/batcher/batcher.md
+++ b/docs/modelserving/batcher/batcher.md
@@ -80,7 +80,7 @@ We can now send requests to the pytorch model using hey.
 The first step is to [determine the ingress IP and ports](../../get_started/first_isvc.md#4-determine-the-ingress-ip-and-ports) and set `INGRESS_HOST` and `INGRESS_PORT`
 
 ```bash
-MODEL_NAME=torchserve
+MODEL_NAME=mnist
 INPUT_PATH=@./input.json
 SERVICE_HOSTNAME=$(kubectl get inferenceservice torchserve -o jsonpath='{.status.url}' | cut -d "/" -f 3)
 


### PR DESCRIPTION
## Context
The model name in the [batcher example](https://kserve.github.io/website/0.10/modelserving/batcher/batcher/) is wrong. Doing the current example results in a model not found error (404). https://github.com/kserve/kserve/issues/2489 also has that issue, even though it is correct in the [PyTorch example docs](https://kserve.github.io/website/master/modelserving/v1beta1/torchserve/).

## Proposed Changes 
- Fixes a wrong model name to avoid 404 for the batcher example.

Fixes https://github.com/kserve/kserve/issues/2489

