### PR TITLE
fix: set default torchserve model store uri to v1

### DIFF
--- a/docs/modelserving/v1beta1/transformer/torchserve_image_transformer/README.md
+++ b/docs/modelserving/v1beta1/transformer/torchserve_image_transformer/README.md
@@ -117,7 +117,7 @@ In this example, the model repository contains a MNIST model, but you can store 
         model:
           modelFormat:
             name: pytorch
-          storageUri: gs://kfserving-examples/models/torchserve/image_classifier
+          storageUri: gs://kfserving-examples/models/torchserve/image_classifier/v1
       transformer:
         containers:
           - image: kserve/image-transformer:latest
@@ -141,7 +141,7 @@ In this example, the model repository contains a MNIST model, but you can store 
     spec:
       predictor:
         pytorch:
-          storageUri: gs://kfserving-examples/models/torchserve/image_classifier
+          storageUri: gs://kfserving-examples/models/torchserve/image_classifier/v1
       transformer:
         containers:
           - image: kserve/image-transformer:latest


### PR DESCRIPTION
## Context
Same as in https://github.com/kserve/kserve/pull/2635. Without `v1` or `v2` specified, the example results in the same issue as in https://github.com/kserve/kserve/issues/2631.

## Proposed Changes
- Use `v1` version as default for the transformer example.
