### PR TITLE
fix up API generation script & regenerate API docs

### DIFF
--- a/docs/hack/gen-api-reference-docs.sh
+++ b/docs/hack/gen-api-reference-docs.sh
@@ -113,7 +113,7 @@ main() {
     # install bin
     gopath="$(mktemp -d)"
     cleanup_gopath_root="${gopath}"
-    env GOPATH="${gopath}"
+    export GOPATH="${gopath}"
     install_go_bin "${REFDOCS_PKG}@${REFDOCS_VER}"
     # move bin to final location
     refdocs_bin="${refdocs_dir}/refdocs"
@@ -133,6 +133,7 @@ main() {
         "${out_dir}/${KSERVE_OUT_FILE}" "${kserve_root}" "./pkg/apis/serving/v1beta1"
 
     cp "${out_dir}/${KSERVE_OUT_FILE}" "$SCRIPTDIR/../reference/${KSERVE_OUT_FILE}"
+    go clean -modcache
 
     # echo "Applying patches..."
     # git apply $SCRIPTDIR/patches/*.patch

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1259,7 +1259,7 @@ It generally has the form http[s]://{route-name}.{route-namespace}.{cluster-leve
 <code>components</code><br/>
 <em>
 <a href="#serving.kserve.io/v1beta1.ComponentStatusSpec">
-map[./pkg/apis/serving/v1beta1.ComponentType]./pkg/apis/serving/v1beta1.ComponentStatusSpec
+map[kserve.io/v1beta1/pkg/apis/serving/v1beta1.ComponentType]kserve.io/v1beta1/pkg/apis/serving/v1beta1.ComponentStatusSpec
 </a>
 </em>
 </td>
@@ -3200,5 +3200,5 @@ PredictorExtensionSpec
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>d42daddd</code>.
+on git commit <code>d7bfd224</code>.
 </em></p>


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`kserve/website` GitHub repository](https://github.com/kserve/website).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/help/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/help/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the KServe blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, add the corresponding "cherrypick-0.X"
label to the original PR; for example, "cherrypick-0.12".
Best practice is to open a PR for the cherry-pick yourself after your original PR has been merged
into the main branch.
After the cherry-pick PR has merged, remove the cherry-pick label from the original PR.

For all resources for contributing to the KServe documentation, see the
[KServe contributor's guide](/docs/help/contributor/mkdocs-contributor-guide.md).

 -->

- Override `GOPATH` in API generation script.
- Regenerate API docs with [latest KServe commit](https://github.com/kserve/kserve/commit/d7bfd224228f8c6888a410b6d1456a8de7d50817) instead of local changes.