### PR TITLE
added step in readme to install requirements.txt

### DIFF
--- a/docs/help/contributor/mkdocs-contributor-guide.md
+++ b/docs/help/contributor/mkdocs-contributor-guide.md
@@ -36,6 +36,20 @@ KServe uses a number of extensions to MkDocs which can also be installed using p
     pip3 install mkdocs-material-extensions mkdocs-macros-plugin mkdocs-exclude mkdocs-awesome-pages-plugin mkdocs-redirects
     ```
 
+## Install Dependencies in Requirements.txt file
+
+Navigate to root folder and run below command to install required packages and libraries specified in the requirements.txt file.
+
+=== "pip"
+    ```
+    pip install -r requirements.txt
+    ```
+
+=== "pip3"
+    ```
+    pip3 install -r requirements.txt
+    ```
+
 ## Setting Up Local Preview
 Once you have installed Material for MkDocs and all of the extensions, head over to
 --8<-- "docs/snippets/links/main-docs-branch-link.md"


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`kserve/website` GitHub repository](https://github.com/kserve/website).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/help/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/help/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the KServe blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, add the corresponding "cherrypick-0.X"
label to the original PR; for example, "cherrypick-0.12".
Best practice is to open a PR for the cherry-pick yourself after your original PR has been merged
into the main branch.
After the cherry-pick PR has merged, remove the cherry-pick label from the original PR.

For all resources for contributing to the KServe documentation, see the
[KServe contributor's guide](/docs/help/contributor/mkdocs-contributor-guide.md).

 -->

Fixes #296 

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Before Change :

<img width="649" alt="image" src="https://github.com/kserve/website/assets/50697244/af4ba18c-18a5-4a2d-ba2a-06f9c44ae3e2">

_mkdocs serve_ commands throws error


- After Change :

<img width="695" alt="image" src="https://github.com/kserve/website/assets/50697244/5e3e34a5-40cc-439d-83bd-8a35926a3a3b">

After dependencies are installed, _mkdocs serve_ command runs successfully.


