### PR TITLE
Spelling.yml add

### DIFF
--- a/.github/workflows/spelling.yaml
+++ b/.github/workflows/spelling.yaml
@@ -1,0 +1,206 @@
+name: Check Spelling
+
+# Comment management is handled through a secondary job, for details see:
+# https://github.com/check-spelling/check-spelling/wiki/Feature%3A-Restricted-Permissions
+#
+# `jobs.comment-push` runs when a push is made to a repository and the `jobs.spelling` job needs to make a comment
+#   (in odd cases, it might actually run just to collapse a comment, but that's fairly rare)
+#   it needs `contents: write` in order to add a comment.
+#
+# `jobs.comment-pr` runs when a pull_request is made to a repository and the `jobs.spelling` job needs to make a comment
+#   or collapse a comment (in the case where it had previously made a comment and now no longer needs to show a comment)
+#   it needs `pull-requests: write` in order to manipulate those comments.
+
+# Updating pull request branches is managed via comment handling.
+# For details, see: https://github.com/check-spelling/check-spelling/wiki/Feature:-Update-expect-list
+#
+# These elements work together to make it happen:
+#
+# `on.issue_comment`
+#   This event listens to comments by users asking to update the metadata.
+#
+# `jobs.update`
+#   This job runs in response to an issue_comment and will push a new commit
+#   to update the spelling metadata.
+#
+# `with.experimental_apply_changes_via_bot`
+#   Tells the action to support and generate messages that enable it
+#   to make a commit to update the spelling metadata.
+#
+# `with.ssh_key`
+#   In order to trigger workflows when the commit is made, you can provide a
+#   secret (typically, a write-enabled github deploy key).
+#
+#   For background, see: https://github.com/check-spelling/check-spelling/wiki/Feature:-Update-with-deploy-key
+
+# Sarif reporting
+#
+# Access to Sarif reports is generally restricted (by GitHub) to members of the repository.
+#
+# Requires enabling `security-events: write`
+# and configuring the action with `use_sarif: 1`
+#
+#   For information on the feature, see: https://github.com/check-spelling/check-spelling/wiki/Feature:-Sarif-output
+
+# Minimal workflow structure:
+#
+# on:
+#   push:
+#     ...
+#   pull_request_target:
+#     ...
+# jobs:
+#   # you only want the spelling job, all others should be omitted
+#   spelling:
+#     # remove `security-events: write` and `use_sarif: 1`
+#     # remove `experimental_apply_changes_via_bot: 1`
+#     ... otherwise adjust the `with:` as you wish
+
+on:
+  push:
+    branches:
+    - "**"
+    tags-ignore:
+    - "**"
+  pull_request_target:
+    branches:
+    - "**"
+    types:
+    - 'opened'
+    - 'reopened'
+    - 'synchronize'
+  issue_comment:
+    types:
+    - 'created'
+
+jobs:
+  spelling:
+    name: Check Spelling
+    permissions:
+      contents: read
+      pull-requests: read
+      actions: read
+      security-events: write
+    outputs:
+      followup: ${{ steps.spelling.outputs.followup }}
+      internal_state_directory: ${{ steps.spelling.outputs.internal_state_directory }}
+      docker_container: ${{ steps.spelling.outputs.docker_container }}
+    env:
+      workflow_check_commit_messages: commits
+    runs-on: ubuntu-latest
+    if: ${{ contains(github.event_name, 'pull_request') || github.event_name == 'push' }}
+    concurrency:
+      group: spelling-${{ github.event.pull_request.number || github.ref }}
+      # note: If you use only_check_changed_files, you do not want cancel-in-progress
+      cancel-in-progress: true
+    steps:
+    - name: checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: ${{ !contains(env.workflow_check_commit_messages, 'commits') && '1' || '0' }}
+    - name: test-clean
+      shell: bash
+      run:
+        cp -R . ../introspected/;
+        mv ../introspected .
+    - name: test-merge
+      if: ${{ contains(github.event_name, 'pull_request') }}
+      uses: check-spelling/checkout-merge@v0.0.4
+      with:
+        path: introspected
+    - name: check-spelling
+      if: env.MERGE_FAILED != '1'
+      id: spelling
+      uses: ./
+      with:
+        suppress_push_for_open_pull_request: 1
+        check_file_names: 1
+        experimental_path: introspected
+        spell_check_this: check-spelling/spell-check-this@prerelease
+        checkout: false
+        post_comment: 0
+        use_magic_file: 1
+        report-timing: 1
+        experimental_apply_changes_via_bot: 1
+        use_sarif: ${{ (!github.event.pull_request || (github.event.pull_request.head.repo.full_name == github.repository)) && 1 }}
+        extra_dictionary_limit: 10
+        # this repository doesn't use php, but the dictionary has fairly good coverage
+        extra_dictionaries:
+          cspell:software-terms/dict/softwareTerms.txt
+          cspell:php/dict/php.txt
+          cspell:node/node.txt
+          cspell:python/src/python/python-lib.txt
+        check_commit_messages: ${{ env.workflow_check_commit_messages }}
+        ignore-pattern: '[^\p{Ll}\p{Lm}\p{Lt}\p{Lu}]'
+        upper-pattern: '[\p{Lu}\p{Lt}\p{Lm}]'
+        lower-pattern: '[\p{Ll}\p{Lm}]'
+        not-lower-pattern: '[^\p{Ll}\p{Lm}]'
+        not-upper-or-lower-pattern: '[^\p{Lu}\p{Lt}\p{Lm}]'
+        punctuation-pattern: "'"
+
+  comment-push:
+    name: Report (Push)
+    # If your workflow isn't running on push, you can remove this job
+    runs-on: ubuntu-latest
+    needs: spelling
+    permissions:
+      contents: write
+    if: (success() || failure()) && needs.spelling.outputs.followup && github.event_name == 'push'
+    steps:
+    - name: checkout
+      uses: actions/checkout@v4
+    - name: comment
+      uses: ./
+      with:
+        checkout: false
+        spell_check_this: check-spelling/spell-check-this@prerelease
+        task: ${{ needs.spelling.outputs.followup }}
+        internal_state_directory: ${{ needs.spelling.outputs.docker_container && needs.spelling.outputs.internal_state_directory }}
+        caller_container: ${{ needs.spelling.outputs.docker_container }}
+
+  comment-pr:
+    name: Report (PR)
+    # If you workflow isn't running on pull_request*, you can remove this job
+    runs-on: ubuntu-latest
+    needs: spelling
+    permissions:
+      contents: read
+      pull-requests: write
+    if: (success() || failure()) && needs.spelling.outputs.followup && contains(github.event_name, 'pull_request')
+    steps:
+    - name: checkout
+      uses: actions/checkout@v4
+    - name: comment
+      uses: ./
+      with:
+        checkout: false
+        spell_check_this: check-spelling/spell-check-this@prerelease
+        task: ${{ needs.spelling.outputs.followup }}
+        internal_state_directory: ${{ needs.spelling.outputs.docker_container && needs.spelling.outputs.internal_state_directory }}
+        caller_container: ${{ needs.spelling.outputs.docker_container }}
+        experimental_apply_changes_via_bot: 1
+
+  update:
+    name: Update PR
+    permissions:
+      contents: write
+      pull-requests: write
+      actions: read
+    runs-on: ubuntu-latest
+    if: ${{
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        contains(github.event.comment.body, '@check-spelling-bot apply')
+      }}
+    concurrency:
+      group: spelling-update-${{ github.event.issue.number }}
+      cancel-in-progress: false
+    steps:
+    - name: checkout
+      uses: actions/checkout@v4
+    - name: apply spelling updates
+      uses: ./
+      with:
+        experimental_apply_changes_via_bot: 1
+        checkout: false
+        ssh_key: "${{ secrets.CHECK_SPELLING }}"

--- a/.github/workflows/spelling.yaml
+++ b/.github/workflows/spelling.yaml
@@ -62,13 +62,16 @@ on:
     - "**"
     tags-ignore:
     - "**"
-  pull_request:
+  pull_request_target:
     branches:
     - "**"
     types:
     - 'opened'
     - 'reopened'
     - 'synchronize'
+  issue_comment:
+    types:
+    - 'created'
 
 jobs:
   spelling:
@@ -80,60 +83,30 @@ jobs:
       security-events: write
     outputs:
       followup: ${{ steps.spelling.outputs.followup }}
-      internal_state_directory: ${{ steps.spelling.outputs.internal_state_directory }}
-      docker_container: ${{ steps.spelling.outputs.docker_container }}
-    env:
-      workflow_check_commit_messages: commits
     runs-on: ubuntu-latest
-    # if: ${{ contains(github.event_name, 'pull_request') || github.event_name == 'push' }}
+    if: ${{ contains(github.event_name, 'pull_request') || github.event_name == 'push' }}
     concurrency:
       group: spelling-${{ github.event.pull_request.number || github.ref }}
       # note: If you use only_check_changed_files, you do not want cancel-in-progress
       cancel-in-progress: true
     steps:
-    - name: checkout
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: ${{ !contains(env.workflow_check_commit_messages, 'commits') && '1' || '0' }}
-    # - name: test-clean
-    #   shell: bash
-    #   run:
-    #     cp -R . ../introspected/;
-    #     mv ../introspected .
-    # - name: test-merge
-    #   if: ${{ contains(github.event_name, 'pull_request') }}
-    #   uses: check-spelling/checkout-merge@v0.0.4
-    #   with:
-    #     path: introspected
     - name: check-spelling
-      if: env.MERGE_FAILED != '1'
       id: spelling
-      uses: ./
+      uses: check-spelling/check-spelling@main
       with:
-        suppress_push_for_open_pull_request: 1
+        suppress_push_for_open_pull_request: ${{ github.actor != 'dependabot[bot]' && 1 }}
+        checkout: true
         check_file_names: 1
-        experimental_path: introspected
-        spell_check_this: kserve/website@prerelease
-        checkout: false
+        spell_check_this: check-spelling/spell-check-this@prerelease
         post_comment: 0
         use_magic_file: 1
         report-timing: 1
+        warnings: bad-regex,binary-file,deprecated-feature,large-file,limited-references,no-newline-at-eof,noisy-file,non-alpha-in-dictionary,token-is-substring,unexpected-line-ending,whitespace-in-dictionary,minified-file,unsupported-configuration,no-files-to-check
         experimental_apply_changes_via_bot: 1
         use_sarif: ${{ (!github.event.pull_request || (github.event.pull_request.head.repo.full_name == github.repository)) && 1 }}
-        extra_dictionary_limit: 10
-        # this repository doesn't use php, but the dictionary has fairly good coverage
+        extra_dictionary_limit: 20
         extra_dictionaries:
           cspell:software-terms/dict/softwareTerms.txt
-          cspell:php/dict/php.txt
-          cspell:node/node.txt
-          cspell:python/src/python/python-lib.txt
-        check_commit_messages: ${{ env.workflow_check_commit_messages }}
-        ignore-pattern: '[^\p{Ll}\p{Lm}\p{Lt}\p{Lu}]'
-        upper-pattern: '[\p{Lu}\p{Lt}\p{Lm}]'
-        lower-pattern: '[\p{Ll}\p{Lm}]'
-        not-lower-pattern: '[^\p{Ll}\p{Lm}]'
-        not-upper-or-lower-pattern: '[^\p{Lu}\p{Lt}\p{Lm}]'
-        punctuation-pattern: "'"
 
   comment-push:
     name: Report (Push)
@@ -144,16 +117,12 @@ jobs:
       contents: write
     if: (success() || failure()) && needs.spelling.outputs.followup && github.event_name == 'push'
     steps:
-    - name: checkout
-      uses: check-spelling/check-spelling@main
     - name: comment
-      uses: ./
+      uses: check-spelling/check-spelling@main
       with:
-        checkout: false
-        spell_check_this: kserve/website@prerelease
+        checkout: true
+        spell_check_this: check-spelling/spell-check-this@prerelease
         task: ${{ needs.spelling.outputs.followup }}
-        internal_state_directory: ${{ needs.spelling.outputs.docker_container && needs.spelling.outputs.internal_state_directory }}
-        caller_container: ${{ needs.spelling.outputs.docker_container }}
 
   comment-pr:
     name: Report (PR)
@@ -165,16 +134,12 @@ jobs:
       pull-requests: write
     if: (success() || failure()) && needs.spelling.outputs.followup && contains(github.event_name, 'pull_request')
     steps:
-    - name: checkout
-      uses: check-spelling/check-spelling@main
     - name: comment
-      uses: ./
+      uses: check-spelling/check-spelling@main
       with:
-        checkout: false
-        spell_check_this: kserve/website@prerelease
+        checkout: true
+        spell_check_this: check-spelling/spell-check-this@prerelease
         task: ${{ needs.spelling.outputs.followup }}
-        internal_state_directory: ${{ needs.spelling.outputs.docker_container && needs.spelling.outputs.internal_state_directory }}
-        caller_container: ${{ needs.spelling.outputs.docker_container }}
         experimental_apply_changes_via_bot: 1
 
   update:
@@ -193,11 +158,9 @@ jobs:
       group: spelling-update-${{ github.event.issue.number }}
       cancel-in-progress: false
     steps:
-    - name: checkout
-      uses: actions/checkout@v4
     - name: apply spelling updates
-      uses: ./
+      uses: check-spelling/check-spelling@main
       with:
         experimental_apply_changes_via_bot: 1
-        checkout: false
+        checkout: true
         ssh_key: "${{ secrets.CHECK_SPELLING }}"

--- a/.github/workflows/spelling.yaml
+++ b/.github/workflows/spelling.yaml
@@ -69,9 +69,9 @@ on:
     - 'opened'
     - 'reopened'
     - 'synchronize'
-  issue_comment:
-    types:
-    - 'created'
+  # issue_comment:
+  #   types:
+  #   - 'created'
 
 jobs:
   spelling:
@@ -83,30 +83,60 @@ jobs:
       security-events: write
     outputs:
       followup: ${{ steps.spelling.outputs.followup }}
+      internal_state_directory: ${{ steps.spelling.outputs.internal_state_directory }}
+      docker_container: ${{ steps.spelling.outputs.docker_container }}
+    env:
+      workflow_check_commit_messages: commits
     runs-on: ubuntu-latest
-    if: ${{ contains(github.event_name, 'pull_request') || github.event_name == 'push' }}
+    # if: ${{ contains(github.event_name, 'pull_request') || github.event_name == 'push' }}
     concurrency:
       group: spelling-${{ github.event.pull_request.number || github.ref }}
       # note: If you use only_check_changed_files, you do not want cancel-in-progress
       cancel-in-progress: true
     steps:
-    - name: check-spelling
-      id: spelling
-      uses: check-spelling/check-spelling@main
+    - name: checkout
+      uses: actions/checkout@v4
       with:
-        suppress_push_for_open_pull_request: ${{ github.actor != 'dependabot[bot]' && 1 }}
-        checkout: true
+        fetch-depth: ${{ !contains(env.workflow_check_commit_messages, 'commits') && '1' || '0' }}
+    # - name: test-clean
+    #   shell: bash
+    #   run:
+    #     cp -R . ../introspected/;
+    #     mv ../introspected .
+    # - name: test-merge
+    #   if: ${{ contains(github.event_name, 'pull_request') }}
+    #   uses: check-spelling/checkout-merge@v0.0.4
+    #   with:
+    #     path: introspected
+    - name: check-spelling
+      if: env.MERGE_FAILED != '1'
+      id: spelling
+      uses: ./
+      with:
+        suppress_push_for_open_pull_request: 1
         check_file_names: 1
+        experimental_path: introspected
         spell_check_this: check-spelling/spell-check-this@prerelease
+        checkout: false
         post_comment: 0
         use_magic_file: 1
         report-timing: 1
-        warnings: bad-regex,binary-file,deprecated-feature,large-file,limited-references,no-newline-at-eof,noisy-file,non-alpha-in-dictionary,token-is-substring,unexpected-line-ending,whitespace-in-dictionary,minified-file,unsupported-configuration,no-files-to-check
         experimental_apply_changes_via_bot: 1
         use_sarif: ${{ (!github.event.pull_request || (github.event.pull_request.head.repo.full_name == github.repository)) && 1 }}
-        extra_dictionary_limit: 20
+        extra_dictionary_limit: 10
+        # this repository doesn't use php, but the dictionary has fairly good coverage
         extra_dictionaries:
           cspell:software-terms/dict/softwareTerms.txt
+          cspell:php/dict/php.txt
+          cspell:node/node.txt
+          cspell:python/src/python/python-lib.txt
+        check_commit_messages: ${{ env.workflow_check_commit_messages }}
+        ignore-pattern: '[^\p{Ll}\p{Lm}\p{Lt}\p{Lu}]'
+        upper-pattern: '[\p{Lu}\p{Lt}\p{Lm}]'
+        lower-pattern: '[\p{Ll}\p{Lm}]'
+        not-lower-pattern: '[^\p{Ll}\p{Lm}]'
+        not-upper-or-lower-pattern: '[^\p{Lu}\p{Lt}\p{Lm}]'
+        punctuation-pattern: "'"
 
   comment-push:
     name: Report (Push)
@@ -117,12 +147,16 @@ jobs:
       contents: write
     if: (success() || failure()) && needs.spelling.outputs.followup && github.event_name == 'push'
     steps:
+    - name: checkout
+      uses: actions/checkout@v4
     - name: comment
-      uses: check-spelling/check-spelling@main
+      uses: ./
       with:
-        checkout: true
+        checkout: false
         spell_check_this: check-spelling/spell-check-this@prerelease
         task: ${{ needs.spelling.outputs.followup }}
+        internal_state_directory: ${{ needs.spelling.outputs.docker_container && needs.spelling.outputs.internal_state_directory }}
+        caller_container: ${{ needs.spelling.outputs.docker_container }}
 
   comment-pr:
     name: Report (PR)
@@ -134,12 +168,16 @@ jobs:
       pull-requests: write
     if: (success() || failure()) && needs.spelling.outputs.followup && contains(github.event_name, 'pull_request')
     steps:
+    - name: checkout
+      uses: actions/checkout@v4
     - name: comment
-      uses: check-spelling/check-spelling@main
+      uses: ./
       with:
-        checkout: true
+        checkout: false
         spell_check_this: check-spelling/spell-check-this@prerelease
         task: ${{ needs.spelling.outputs.followup }}
+        internal_state_directory: ${{ needs.spelling.outputs.docker_container && needs.spelling.outputs.internal_state_directory }}
+        caller_container: ${{ needs.spelling.outputs.docker_container }}
         experimental_apply_changes_via_bot: 1
 
   update:
@@ -158,9 +196,11 @@ jobs:
       group: spelling-update-${{ github.event.issue.number }}
       cancel-in-progress: false
     steps:
+    - name: checkout
+      uses: actions/checkout@v4
     - name: apply spelling updates
-      uses: check-spelling/check-spelling@main
+      uses: ./
       with:
         experimental_apply_changes_via_bot: 1
-        checkout: true
+        checkout: false
         ssh_key: "${{ secrets.CHECK_SPELLING }}"

--- a/.github/workflows/spelling.yaml
+++ b/.github/workflows/spelling.yaml
@@ -92,7 +92,7 @@ jobs:
       cancel-in-progress: true
     steps:
     - name: checkout
-      uses: check-spelling/check-spelling@main
+      uses: actions/checkout@v4
       with:
         fetch-depth: ${{ !contains(env.workflow_check_commit_messages, 'commits') && '1' || '0' }}
     # - name: test-clean
@@ -113,7 +113,7 @@ jobs:
         suppress_push_for_open_pull_request: 1
         check_file_names: 1
         experimental_path: introspected
-        spell_check_this: check-spelling/spell-check-this@prerelease
+        spell_check_this: kserve/website@prerelease
         checkout: false
         post_comment: 0
         use_magic_file: 1
@@ -150,7 +150,7 @@ jobs:
       uses: ./
       with:
         checkout: false
-        spell_check_this: check-spelling/spell-check-this@prerelease
+        spell_check_this: kserve/website@prerelease
         task: ${{ needs.spelling.outputs.followup }}
         internal_state_directory: ${{ needs.spelling.outputs.docker_container && needs.spelling.outputs.internal_state_directory }}
         caller_container: ${{ needs.spelling.outputs.docker_container }}
@@ -171,7 +171,7 @@ jobs:
       uses: ./
       with:
         checkout: false
-        spell_check_this: check-spelling/spell-check-this@prerelease
+        spell_check_this: kserve/website@prerelease
         task: ${{ needs.spelling.outputs.followup }}
         internal_state_directory: ${{ needs.spelling.outputs.docker_container && needs.spelling.outputs.internal_state_directory }}
         caller_container: ${{ needs.spelling.outputs.docker_container }}
@@ -194,7 +194,7 @@ jobs:
       cancel-in-progress: false
     steps:
     - name: checkout
-      uses: check-spelling/check-spelling@main
+      uses: actions/checkout@v4
     - name: apply spelling updates
       uses: ./
       with:

--- a/.github/workflows/spelling.yaml
+++ b/.github/workflows/spelling.yaml
@@ -62,16 +62,13 @@ on:
     - "**"
     tags-ignore:
     - "**"
-  pull_request_target:
+  pull_request:
     branches:
     - "**"
     types:
     - 'opened'
     - 'reopened'
     - 'synchronize'
-  issue_comment:
-    types:
-    - 'created'
 
 jobs:
   spelling:
@@ -88,26 +85,26 @@ jobs:
     env:
       workflow_check_commit_messages: commits
     runs-on: ubuntu-latest
-    if: ${{ contains(github.event_name, 'pull_request') || github.event_name == 'push' }}
+    # if: ${{ contains(github.event_name, 'pull_request') || github.event_name == 'push' }}
     concurrency:
       group: spelling-${{ github.event.pull_request.number || github.ref }}
       # note: If you use only_check_changed_files, you do not want cancel-in-progress
       cancel-in-progress: true
     steps:
     - name: checkout
-      uses: actions/checkout@v4
+      uses: check-spelling/check-spelling@main
       with:
         fetch-depth: ${{ !contains(env.workflow_check_commit_messages, 'commits') && '1' || '0' }}
-    - name: test-clean
-      shell: bash
-      run:
-        cp -R . ../introspected/;
-        mv ../introspected .
-    - name: test-merge
-      if: ${{ contains(github.event_name, 'pull_request') }}
-      uses: check-spelling/checkout-merge@v0.0.4
-      with:
-        path: introspected
+    # - name: test-clean
+    #   shell: bash
+    #   run:
+    #     cp -R . ../introspected/;
+    #     mv ../introspected .
+    # - name: test-merge
+    #   if: ${{ contains(github.event_name, 'pull_request') }}
+    #   uses: check-spelling/checkout-merge@v0.0.4
+    #   with:
+    #     path: introspected
     - name: check-spelling
       if: env.MERGE_FAILED != '1'
       id: spelling
@@ -148,7 +145,7 @@ jobs:
     if: (success() || failure()) && needs.spelling.outputs.followup && github.event_name == 'push'
     steps:
     - name: checkout
-      uses: actions/checkout@v4
+      uses: check-spelling/check-spelling@main
     - name: comment
       uses: ./
       with:
@@ -169,7 +166,7 @@ jobs:
     if: (success() || failure()) && needs.spelling.outputs.followup && contains(github.event_name, 'pull_request')
     steps:
     - name: checkout
-      uses: actions/checkout@v4
+      uses: check-spelling/check-spelling@main
     - name: comment
       uses: ./
       with:
@@ -197,7 +194,7 @@ jobs:
       cancel-in-progress: false
     steps:
     - name: checkout
-      uses: actions/checkout@v4
+      uses: check-spelling/check-spelling@main
     - name: apply spelling updates
       uses: ./
       with:

--- a/.github/workflows/spelling.yaml
+++ b/.github/workflows/spelling.yaml
@@ -69,9 +69,9 @@ on:
     - 'opened'
     - 'reopened'
     - 'synchronize'
-  # issue_comment:
-  #   types:
-  #   - 'created'
+  issue_comment:
+    types:
+    - 'created'
 
 jobs:
   spelling:
@@ -88,7 +88,7 @@ jobs:
     env:
       workflow_check_commit_messages: commits
     runs-on: ubuntu-latest
-    # if: ${{ contains(github.event_name, 'pull_request') || github.event_name == 'push' }}
+    if: ${{ contains(github.event_name, 'pull_request') || github.event_name == 'push' }}
     concurrency:
       group: spelling-${{ github.event.pull_request.number || github.ref }}
       # note: If you use only_check_changed_files, you do not want cancel-in-progress
@@ -98,16 +98,16 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: ${{ !contains(env.workflow_check_commit_messages, 'commits') && '1' || '0' }}
-    # - name: test-clean
-    #   shell: bash
-    #   run:
-    #     cp -R . ../introspected/;
-    #     mv ../introspected .
-    # - name: test-merge
-    #   if: ${{ contains(github.event_name, 'pull_request') }}
-    #   uses: check-spelling/checkout-merge@v0.0.4
-    #   with:
-    #     path: introspected
+    - name: test-clean
+      shell: bash
+      run:
+        cp -R . ../introspected/;
+        mv ../introspected .
+    - name: test-merge
+      if: ${{ contains(github.event_name, 'pull_request') }}
+      uses: check-spelling/checkout-merge@v0.0.4
+      with:
+        path: introspected
     - name: check-spelling
       if: env.MERGE_FAILED != '1'
       id: spelling

--- a/spell-test.txt
+++ b/spell-test.txt
@@ -1,0 +1,1 @@
+Thsi flie will chekc for spellign erors.


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`kserve/website` GitHub repository](https://github.com/kserve/website).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/help/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/help/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the KServe blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, add the corresponding "cherrypick-0.X"
label to the original PR; for example, "cherrypick-0.12".
Best practice is to open a PR for the cherry-pick yourself after your original PR has been merged
into the main branch.
After the cherry-pick PR has merged, remove the cherry-pick label from the original PR.

For all resources for contributing to the KServe documentation, see the
[KServe contributor's guide](/docs/help/contributor/mkdocs-contributor-guide.md).

 -->

"Fixes #82 "
"I have added two files,
  1. Spelling.yml which will run when a new commit is made & check for spelling mistakes.
  2. Also added the spell-test.txt, for verification purpose."
  

