### PR TITLE
Added dark and light mode toggle.

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,7 +1,6 @@
 :root {
   --md-primary-fg-color: #1a7dc9;
   --home-color: #0071c7;
-  --nav-item-color: #4d4d4d;
 }
 
 .md-clipboard {
@@ -255,3 +254,6 @@
   background: rgb(228, 255, 218);
 }
 
+[data-md-color-scheme=slate] #release-update {
+  color: #756A54;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -140,6 +140,19 @@ theme:
     - navigation.tracking
     - navigation.tabs.sticky
     - navigation.top
+  palette: 
+    # Palette toggle for light mode
+    - scheme: default
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+
+    # Palette toggle for dark mode
+    - scheme: slate
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
+
 
 markdown_extensions:
   - markdown_include.include:
@@ -183,7 +196,6 @@ plugins:
      css_dir: css
      javascript_dir: js
   - swagger-ui-tag:
-        background: White
         docExpansion: none
         filter: ""
         syntaxHighlightTheme: monokai


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`kserve/website` GitHub repository](https://github.com/kserve/website).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/help/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/help/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the KServe blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, add the corresponding "cherrypick-0.X"
label to the original PR; for example, "cherrypick-0.12".
Best practice is to open a PR for the cherry-pick yourself after your original PR has been merged
into the main branch.
After the cherry-pick PR has merged, remove the cherry-pick label from the original PR.

For all resources for contributing to the KServe documentation, see the
[KServe contributor's guide](/docs/help/contributor/mkdocs-contributor-guide.md).

 -->

"Fixes #309" Enable dark mode in website

## Proposed Changes <!-- Describe the changes the PR makes. -->

-
-
-

