### PR TITLE
clarify prometheus annotation

### DIFF
--- a/docs/modelserving/observability/prometheus_metrics.md
+++ b/docs/modelserving/observability/prometheus_metrics.md
@@ -35,6 +35,9 @@ The default values for `serving.kserve.io/enable-prometheus-scraping` can be set
 
 There is not currently a unified set of metrics exported by the model servers. Each model server may implement its own set of metrics to export. 
 
+!!! note
+    This annotation defines the prometheus port and path, but it does not trigger the prometheus to scrape. Users must configure prometheus to scrape data from inference service's pod according to the prometheus settings.
+
 ## Metrics for lgbserver, paddleserver, pmmlserver, sklearnserver, xgbserver, custom transformer/predictor
 
 Prometheus latency histograms are emitted for each of the steps (pre/postprocessing, explain, predict).


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`kserve/website` GitHub repository](https://github.com/kserve/website).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/help/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/help/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the KServe blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, add the corresponding "cherrypick-0.X"
label to the original PR; for example, "cherrypick-0.12".
Best practice is to open a PR for the cherry-pick yourself after your original PR has been merged
into the main branch.
After the cherry-pick PR has merged, remove the cherry-pick label from the original PR.

For all resources for contributing to the KServe documentation, see the
[KServe contributor's guide](/docs/help/contributor/mkdocs-contributor-guide.md).

 -->

"Fixes #315"

## Proposed Changes <!-- Describe the changes the PR makes. -->

- clarify `serving.kserve.io/enable-prometheus-scraping` is setting port and path for prometheus and users should make prometheus scrape kserve container

Since I'm not a native English speaker, please edit the message if it is not natural.
