### PR TITLE
Fixed formatting in get_started

### DIFF
--- a/docs/get_started/README.md
+++ b/docs/get_started/README.md
@@ -20,17 +20,21 @@ The [Kubernetes CLI (`kubectl`)](https://kubernetes.io/docs/tasks/tools/install-
     ```bash
     kind create cluster
     ```
+
 2. Then run:
 
-   ```bash
-   kubectl config get-contexts
-   ```
-   It should list out a list of contexts you have, one of them should be `kind-kind`. Then run:
+    ```bash
+    kubectl config get-contexts
+    ```
 
-   ```bash
-   kubectl config use-context kind-kind
-   ```
-   to use this context
+    It should list out a list of contexts you have, one of them should be `kind-kind`. Then run:
+
+    ```bash
+    kubectl config use-context kind-kind
+    ```
+
+    to use this context.
+
 3. You can then get started with a local deployment of KServe by using _KServe Quick installation script on Kind_:
 
     ```bash


### PR DESCRIPTION
Fixes formatting in Get Started.
Before this fix, the Get Started page looks like:

![Screenshot from 2023-11-16 16-40-52](https://github.com/kserve/website/assets/11776454/3829311d-3d29-41d2-bbfd-652a7d4b1908)

After the fix:

![Screenshot from 2023-11-16 16-41-46](https://github.com/kserve/website/assets/11776454/8b462383-5281-4f8e-a4af-9825a140a9ee)
