### PR TITLE
Fix incorrect edit URL to docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -115,7 +115,7 @@ extra_css:
   - stylesheets/extra.css
 
 repo_url: https://github.com/kserve/kserve
-edit_uri: edit/main/docs
+edit_uri: https://github.com/kserve/website/edit/main/docs
 
 theme:
   name: material


### PR DESCRIPTION
Since the repo is kserve/kserve but the docs are hosted on kserve/website, the current edit URL does not work and lead to a 404 page. This PR should fix that.

![image](https://github.com/kserve/website/assets/4269898/34561b27-0fe1-418d-acbb-466d8ff0d4d6)