### PR TITLE
Added steps to delete model-store-pod

### DIFF
--- a/docs/modelserving/storage/pvc/pvc.md
+++ b/docs/modelserving/storage/pvc/pvc.md
@@ -78,11 +78,13 @@ kubectl apply -f pv-model-store.yaml
 kubectl exec -it model-store-pod -- bash
 ```
 
-In different terminal, copy the model from local into PV.
+In different terminal, copy the model from local into PV, then delete `model-store-pod`.
 
 === "kubectl"
 ```bash
 kubectl cp model.joblib model-store-pod:/pv/model.joblib -c model-store
+
+kubectl delete pod model-store-pod
 ```
 
 ## Deploy `InferenceService` with models on PVC


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`kserve/website` GitHub repository](https://github.com/kserve/website).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/help/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/help/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the KServe blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, add the corresponding "cherrypick-0.X"
label to the original PR; for example, "cherrypick-0.12".
Best practice is to open a PR for the cherry-pick yourself after your original PR has been merged
into the main branch.
After the cherry-pick PR has merged, remove the cherry-pick label from the original PR.

For all resources for contributing to the KServe documentation, see the
[KServe contributor's guide](/docs/help/contributor/mkdocs-contributor-guide.md).

 -->

"Fixes #issue-number" or "Add description of the problem this PR solves"

If you have configured a k8s cluster with multiple workers, creating `InferenceService` may fail if you follow this procedure.
https://kserve.github.io/website/0.11/modelserving/storage/pvc/pvc/

This is because `InferenceService's pod` and `model-store-pod` may be located on different servers even though the `pvc` is RWO.

By deleting `model-store-pod` before creating `InferenceService`, it is now possible to create `InferenceService` without failure.

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Added steps to delete model-store-pod

