### PR TITLE
Add ModelRegistry custom storage intializer example

### DIFF
--- a/docs/modelserving/storage/storagecontainers.md
+++ b/docs/modelserving/storage/storagecontainers.md
@@ -46,7 +46,7 @@ The first step is to create a custom container image that will be injected into 
 
 The only requirement is that the `Entrypoint` of this container image should take (and properly manage) 2 positional arguments:
 1. __Source URI__: identifies the `storageUri` set in the `InferenceService`
-2. __Deestination Path__: the location where the model should be stored, e.g., `/mnt/models`
+2. __Destination Path__: the location where the model should be stored, e.g., `/mnt/models`
 
 !!! note
     KServe controller will take care of properly injecting your container image and invoking it with those proper arguments.

--- a/docs/modelserving/storage/storagecontainers.md
+++ b/docs/modelserving/storage/storagecontainers.md
@@ -36,10 +36,32 @@ In a _ClusterStorageContainer_ spec, you can specify container resource requests
 
     If a storage URI is supported by two or more _ClusterStorageContainer_ CRs, there is no guarantee which one will be used. **Please make sure that the URI format is only supported by one ClusterStorageContainer CR**.
 
+## Custom Protocol Example
 
-If you would like to use a custom protocol `model-registry://`, for example, you can create a custom image and add a new ClusterStorageContainer CR like this:
+If you would like to use a custom protocol `model-registry://`, for example, you can create a custom image and add a new `ClusterStorageContainer` CR to make it available to KServe.
 
-```yaml
+### Create the `Custom Storage Initializer` Image
+
+The first step is to create a custom container image that will be injected into the KServe deployment, as init container, and that will be in charge to download the model.
+
+The only requirement is that the `Entrypoint` of this container image should take (and properly manage) 2 positional arguments:
+1. __Source URI__: identifies the `storageUri` set in the `InferenceService`
+2. __Deestination Path__: the location where the model should be stored, e.g., `/mnt/models`
+
+!!! note
+    KServe controller will take care of properly injecting your container image and invoking it with those proper arguments.
+
+A more concrete example can be found [here](https://github.com/lampajr/model-registry-storage-initializer), where the storage initializer query an existing `model registry` service in order to retrieve the original location of the model that the user requested to deploy. 
+
+###  Create the `ClusterStorageContainer` CR
+
+Once the Custom Storage Initializer image is ready, you just need to create a new `ClusterStorageContainer` CR to make it available in the cluster. You just need to provide 2 essential information:
+1. The _container spec definition_, this is strictly dependent on your own custom storage initializer image.
+2. The _supported uri formats_ for which your custom storage initializer should be injected, in this case just `model-registry://`.
+
+=== "kubectl"
+```bash
+kubectl apply -f - <<EOF
 apiVersion: "serving.kserve.io/v1alpha1"
 kind: ClusterStorageContainer
 metadata:
@@ -47,7 +69,12 @@ metadata:
 spec:
   container:
     name: storage-initializer
-    image: abc/custom-storage-initializer:latest
+    image: abc/model-registry-storage-initializer:latest
+    env:
+    - name: MODEL_REGISTRY_BASE_URL
+      value: "$MODEL_REGISTRY_SERVICE.model-registry.svc.cluster.local:$MODEL_REGISTRY_REST_PORT"
+    - name: MODEL_REGISTRY_SCHEME
+      value: "http"
     resources:
       requests:
         memory: 100Mi
@@ -57,7 +84,34 @@ spec:
         cpu: "1"
   supportedUriFormats:
     - prefix: model-registry://
+
+EOF
 ```
+
+### Deploy the Model with `InferenceService`
+
+Create the `InferenceService` with the `model-registry` specific URI format.
+
+=== "kubectl"
+```bash
+kubectl apply -n kserve-test -f - <<EOF
+apiVersion: "serving.kserve.io/v1beta1"
+kind: "InferenceService"
+metadata:
+  name: "iris-model"
+spec:
+  predictor:
+    model:
+      modelFormat:
+        name: sklearn
+      storageUri: "model-registry://iris/v1"
+EOF
+```
+
+!!! note
+    The only assumption here is that the ML model you are going to deploy has been already registered in the Model Registry, more information can be found in the [kubeflow/model-registry](https://github.com/kubeflow/model-registry) repository.
+
+In this specific example the `model-registry://iris/v1` model is referring to a registered model pointing to `gs://kfserving-examples/models/sklearn/1.0/model`. The crucial point here is that this information needs to be provided just during the registration process, whereas during every deployment action you just need to provide the `model-registry` specific URI that identifies that model (in this case `model-registry://${MODEL_NAME}/${MODEL_VERSION}`).
 
 ## Spec Attributes
 


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`kserve/website` GitHub repository](https://github.com/kserve/website).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/help/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/help/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the KServe blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, add the corresponding "cherrypick-0.X"
label to the original PR; for example, "cherrypick-0.12".
Best practice is to open a PR for the cherry-pick yourself after your original PR has been merged
into the main branch.
After the cherry-pick PR has merged, remove the cherry-pick label from the original PR.

For all resources for contributing to the KServe documentation, see the
[KServe contributor's guide](/docs/help/contributor/mkdocs-contributor-guide.md).

 -->

Fixes https://github.com/kserve/kserve/issues/3343

## Proposed Changes <!-- Describe the changes the PR makes. -->

- As suggested here https://github.com/kserve/kserve/issues/3343#issuecomment-1943718908 I am proposing a more concrete example of the `ClusterStorageContainer` usage leveraging the [kubeflow/model-registry](https://github.com/kubeflow/model-registry) component.
- Enhanced the [storagecontainers](https://kserve.github.io/website/0.11/modelserving/storage/storagecontainers/) webpage by providing some additional details regarding how to create your custom image.
- I also referenced some external repositories, in particular [lampajr/model-registry-storage-initializer](https://github.com/lampajr/model-registry-storage-initializer) the one I created to showcase this extension/integration.

