### PR TITLE
docs: fix the emoji deprecation message and invalid file name

### DIFF
--- a/docs/modelserving/v1beta1/torchserve/README.md
+++ b/docs/modelserving/v1beta1/torchserve/README.md
@@ -209,7 +209,7 @@ _**Note**_: Since kserve has no grpc client methods for v1, we are using torchse
 
 For deploying the `InferenceService` with gRPC protocol you need to expose the gRPC port on InferenceService. Here **7070** is torchserve gRPC port.
 
-Apply the following [mnist_grpc.yaml](./mnist.yaml) to create the `InferenceService`.
+Apply the following [mnist_grpc.yaml](./mnist_grpc.yaml) to create the `InferenceService`.
 
 === "kubectl"
 ```bash
@@ -219,7 +219,7 @@ kubectl apply -f mnist_grpc.yaml
 Expected Output
 
 ```bash
-$inferenceservice.serving.kserve.io/torchserve-grpc created
+inferenceservice.serving.kserve.io/torchserve-grpc created
 ```
 
 === "New Schema"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -136,8 +136,8 @@ markdown_extensions:
   # - mdx_include:
   #     base_path: docs
   - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
+      emoji_index: !!python/name:pymdownx.emoji.twemoji
+      emoji_generator: !!python/name:pymdownx.emoji.to_svg
   - attr_list
   - meta
   - pymdownx.superfences


### PR DESCRIPTION
Fixes the following minor issues:

- reference to invalid .yaml file
- deprecated emoji warning (ref: https://github.com/squidfunk/mkdocs-material/discussions/6207)
- extra character in output