### PR TITLE
Add serving runtime logger configuration docs

### DIFF
--- a/docs/modelserving/v1beta1/custom/custom_model/README.md
+++ b/docs/modelserving/v1beta1/custom/custom_model/README.md
@@ -498,13 +498,13 @@ each model as separate python worker and web server routes to the model workers 
 ![parallel_inference](./parallel_inference.png)
 
 ## Configuring Logger for Custom Serving Runtime
-Kserve allows users to override the default logger configuration of serving runtime and uvicorn server.
+KServe allows users to override the default logger configuration of serving runtime and uvicorn server.
 The logger configuration can be modified in one of the following ways:
 
 ### 1. Providing [logger configuration as a Dict](https://docs.python.org/3/library/logging.config.html#configuration-dictionary-schema):
 
 If you are building a custom serving runtime and want to modify the logger configuration, this method offers the easiest solution.
-You can supply the logging configuration as a Python Dictionary to the `kserve.logging.configure_logging()` method.
+You can supply the logging configuration as a Python Dictionary to the `kserve.logging.configure_logging()` method. If the logging dictionary is not provided, KServe uses the default configuration [KSERVE_LOG_CONFIG](https://github.com/kserve/kserve/blob/d19e31040c558ef88774736f67a0c2af7dbc6bc2/python/kserve/kserve/logging.py#L32).
 ```python
 import argparse
 import kserve
@@ -571,7 +571,7 @@ if __name__ == "__main__":
         },
     }
     if args.configure_logging:
-        logging.configure_logging(args.log_config_file)
+        logging.configure_logging(dictConfig)
 ```
 !!! note
 

--- a/docs/modelserving/v1beta1/transformer/torchserve_image_transformer/README.md
+++ b/docs/modelserving/v1beta1/transformer/torchserve_image_transformer/README.md
@@ -14,15 +14,16 @@ To implement a `Transformer` you can derive from the base `Model` class and then
 For `Open(v2) Inference Protocol`, KServe provides `InferRequest` and `InferResponse` API object for `predict`, `preprocess`, `postprocess`
 handlers to abstract away the implementation details of REST/gRPC decoding and encoding over the wire.
 ```python
-from kserve import Model, ModelServer, model_server, InferInput, InferRequest
+import argparse
+from kserve import Model, ModelServer, model_server, InferInput, InferRequest, logging
 from typing import Dict
 from PIL import Image
 import torchvision.transforms as transforms
 import logging
 import io
 import base64
+import kserve
 
-logging.basicConfig(level=kserve.constants.KSERVE_LOGLEVEL)
 
 def image_transform(byte_array):
     """converts the input image of Bytes Array into Tensor
@@ -75,6 +76,8 @@ Please see the code example [here](https://github.com/kserve/kserve/tree/release
 For single model you just create a transformer object and register that to the model server.
 ```python
 if __name__ == "__main__":
+    if args.configure_logging:
+        logging.configure_logging(args.log_config_file)  # Configure kserve and uvicorn logger
     model = ImageTransformer(args.model_name, predictor_host=args.predictor_host,
                              protocol=args.protocol)
     ModelServer().start(models=[model])
@@ -84,11 +87,17 @@ For multi-model case if all the models can share the same transformer you can re
 or different transformers if each model requires its own transformation.
 ```python
 if __name__ == "__main__":
+    if args.configure_logging:
+        logging.configure_logging(args.log_config_file)  # Configure kserve and uvicorn logger
     for model_name in model_names:
         transformer = ImageTransformer(model_name, predictor_host=args.predictor_host)
         models.append(transformer)
     kserve.ModelServer().start(models=models)
 ```
+
+### Configuring Logger for Serving Runtime
+Kserve allows users to override the default logger configuration of serving runtime and uvicorn server.
+You can follow the [logger configuration documentation](../../custom/custom_model/#configuring-logger-for-serving-runtime) to configure the logger.
 
 ### Build Transformer docker image
 Under `kserve/python` directory, build the transformer docker image using [Dockerfile](https://github.com/kserve/kserve/blob/release-0.11/python/custom_transformer.Dockerfile)


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`kserve/website` GitHub repository](https://github.com/kserve/website).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/help/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/help/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the KServe blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, add the corresponding "cherrypick-0.X"
label to the original PR; for example, "cherrypick-0.12".
Best practice is to open a PR for the cherry-pick yourself after your original PR has been merged
into the main branch.
After the cherry-pick PR has merged, remove the cherry-pick label from the original PR.

For all resources for contributing to the KServe documentation, see the
[KServe contributor's guide](/docs/help/contributor/mkdocs-contributor-guide.md).

 -->

"Fixes #issue-number" or "Add description of the problem this PR solves"
Documents the proper way to configuring logger for kserve.
https://github.com/kserve/kserve/pull/3577

## Proposed Changes <!-- Describe the changes the PR makes. -->

-
-
-

