### PR TITLE
Fix issue in docs: typo in dockerfile name, and typo in url.

### DIFF
--- a/docs/modelserving/v1beta1/transformer/torchserve_image_transformer/README.md
+++ b/docs/modelserving/v1beta1/transformer/torchserve_image_transformer/README.md
@@ -70,7 +70,7 @@ class ImageTransformer(kserve.Model):
         return infer_request
 ```
 
-Please see the code example [here](https://github.com/kserve/kserve/tree/release-0.11/python/custom_transformer).
+Please see the code example [here](https://github.com/kserve/kserve/tree/master/python/custom_transformer).
 
 ### Transformer Server Entrypoint
 For single model you just create a transformer object and register that to the model server.
@@ -100,10 +100,10 @@ Kserve allows users to override the default logger configuration of serving runt
 You can follow the [logger configuration documentation](../../custom/custom_model/README.md#configuring-logger-for-serving-runtime) to configure the logger.
 
 ### Build Transformer docker image
-Under `kserve/python` directory, build the transformer docker image using [Dockerfile](https://github.com/kserve/kserve/blob/release-0.11/python/custom_transformer.Dockerfile)
+Under `kserve/python` directory, build the transformer docker image using [Dockerfile](https://github.com/kserve/kserve/blob/master/python/custom_transformer.Dockerfile)
 ```bash
 cd python
-docker build -t $DOCKER_USER/image-transformer:latest -f transformer.Dockerfile .
+docker build -t $DOCKER_USER/image-transformer:latest -f custom_transformer.Dockerfile .
 
 docker push {username}/image-transformer:latest
 ```

--- a/docs/modelserving/v1beta1/transformer/torchserve_image_transformer/README.md
+++ b/docs/modelserving/v1beta1/transformer/torchserve_image_transformer/README.md
@@ -70,7 +70,7 @@ class ImageTransformer(kserve.Model):
         return infer_request
 ```
 
-Please see the code example [here](https://github.com/kserve/kserve/tree/master/python/custom_transformer).
+Please see the code example [here](https://github.com/kserve/kserve/tree/release-0.14/python/custom_transformer).
 
 ### Transformer Server Entrypoint
 For single model you just create a transformer object and register that to the model server.
@@ -100,7 +100,7 @@ Kserve allows users to override the default logger configuration of serving runt
 You can follow the [logger configuration documentation](../../custom/custom_model/README.md#configuring-logger-for-serving-runtime) to configure the logger.
 
 ### Build Transformer docker image
-Under `kserve/python` directory, build the transformer docker image using [Dockerfile](https://github.com/kserve/kserve/blob/master/python/custom_transformer.Dockerfile)
+Under `kserve/python` directory, build the transformer docker image using [Dockerfile](https://github.com/kserve/kserve/blob/release-0.14/python/custom_transformer.Dockerfile)
 ```bash
 cd python
 docker build -t $DOCKER_USER/image-transformer:latest -f custom_transformer.Dockerfile .


### PR DESCRIPTION
Signed-off-by: John Zheng <john.zheng@hp.com>

<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`kserve/website` GitHub repository](https://github.com/kserve/website).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/help/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/help/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the KServe blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, add the corresponding "cherrypick-0.X"
label to the original PR; for example, "cherrypick-0.12".
Best practice is to open a PR for the cherry-pick yourself after your original PR has been merged
into the main branch.
After the cherry-pick PR has merged, remove the cherry-pick label from the original PR.

For all resources for contributing to the KServe documentation, see the
[KServe contributor's guide](/docs/help/contributor/mkdocs-contributor-guide.md).

 -->

"Fixes #issue-number" or "Add description of the problem this PR solves"

## Proposed Changes <!-- Describe the changes the PR makes. -->

-
-
-

