### PR TITLE
update recommended version because of EOL

### DIFF
--- a/docs/admin/kubernetes_deployment.md
+++ b/docs/admin/kubernetes_deployment.md
@@ -32,7 +32,7 @@ spec:
 
 
 ## 2. Install Cert Manager
-The minimally required Cert Manager version is 1.9.0 and you can refer to [Cert Manager installation guide](https://cert-manager.io/docs/installation/).
+The minimally required Cert Manager version is 1.15.0 and you can refer to [Cert Manager installation guide](https://cert-manager.io/docs/installation/).
 
 !!! note
     Cert manager is required to provision webhook certs for production grade installation, alternatively you can run self signed certs generation script.
@@ -72,4 +72,3 @@ then modify the `ingressClassName` in `ingress` section to point to `IngressClas
         "ingressClassName" : "your-ingress-class",
     }
     ```
-

--- a/docs/admin/serverless/serverless.md
+++ b/docs/admin/serverless/serverless.md
@@ -2,15 +2,15 @@
 KServe Serverless installation enables autoscaling based on request volume and supports scale down to and from zero. It also supports revision management
 and canary rollout based on revisions.
 
-Kubernetes 1.22 is the minimally required version and please check the following recommended Knative, Istio versions for the corresponding
+Kubernetes 1.28 is the minimally required version and please check the following recommended Knative, Istio versions for the corresponding
 Kubernetes version.
 
 ## Recommended Version Matrix
 | Kubernetes Version | Recommended Istio Version | Recommended Knative Version |
 |:-------------------|:--------------------------|:----------------------------|
-| 1.27               | 1.18,1.19                 | 1.10,1.11                   |
-| 1.28               | 1.19,1.20                 | 1.11,1.12.4                 |
-| 1.29               | 1.20,1.21                 | 1.12.4,1.13.1               |
+| 1.28               | 1.22                      | 1.15                        |
+| 1.29               | 1.22,1.23                 | 1.15,1.16                   |
+| 1.30               | 1.22,1.23                 | 1.15,1.16                   |
 
 ## 1. Install Knative Serving
 Please refer to [Knative Serving install guide](https://knative.dev/docs/admin/install/serving/install-serving-with-yaml/).
@@ -27,7 +27,7 @@ The recommended networking layer for KServe is [Istio](https://istio.io/) as cur
 Alternatively you can also choose other networking layers like [Kourier](https://github.com/knative-sandbox/net-kourier) or [Contour](https://projectcontour.io/), see [how to install Kourier with KServe guide](./kourier_networking/README.md).
 
 ## 3. Install Cert Manager
-The minimally required Cert Manager version is 1.9.0 and you can refer to [Cert Manager](https://cert-manager.io/docs/installation/).
+The minimally required Cert Manager version is 1.15.0 and you can refer to [Cert Manager](https://cert-manager.io/docs/installation/).
 
 !!! note
     Cert manager is required to provision webhook certs for production grade installation, alternatively you can run self signed certs generation script.


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`kserve/website` GitHub repository](https://github.com/kserve/website).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/help/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/help/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the KServe blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, add the corresponding "cherrypick-0.X"
label to the original PR; for example, "cherrypick-0.12".
Best practice is to open a PR for the cherry-pick yourself after your original PR has been merged
into the main branch.
After the cherry-pick PR has merged, remove the cherry-pick label from the original PR.

For all resources for contributing to the KServe documentation, see the
[KServe contributor's guide](/docs/help/contributor/mkdocs-contributor-guide.md).

 -->

"Fixes #issue-number" or "Add description of the problem this PR solves"

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Knative 1.14 will be EOL soon next week. (Oct/22)
- Kubernetes 1.27 was EOL 
- Cert Manager 1.9 was EOL 
- Istio 1.21 was EOL
- Did not update matrix part in kuberentes_deployment.md because there was another pr created.

Reference:
- kuberenets: https://kubernetes.io/releases/
- cert-mangaer: https://cert-manager.io/docs/releases/#old-cert-manager-releases
- istio: https://istio.io/latest/docs/releases/supported-releases/
- knative: https://github.com/knative/community/blob/main/mechanics/RELEASE-SCHEDULE.md

