### PR TITLE
use global variable for kserve_release_version

### DIFF
--- a/docs/admin/kubernetes_deployment.md
+++ b/docs/admin/kubernetes_deployment.md
@@ -6,7 +6,7 @@ Kubernetes version.
 
 ## Recommended Version Matrix
 | Kubernetes Version | Recommended Istio Version |
-|:-------------------|:--------------------------|
+| :----------------- | :------------------------ |
 | 1.27               | 1.18, 1.19                |
 | 1.28               | 1.19, 1.20                |
 | 1.29               | 1.20, 1.21                |
@@ -46,14 +46,14 @@ The minimally required Cert Manager version is 1.9.0 and you can refer to [Cert 
 
 === "kubectl"
     ```bash
-    kubectl apply -f https://github.com/kserve/kserve/releases/download/v0.13.0/kserve.yaml
+    kubectl apply -f https://github.com/kserve/kserve/releases/download/v{{  kserve_release_version }}/kserve.yaml
     ```
 
 Install KServe default serving runtimes:
 
 === "kubectl"
     ```bash
-    kubectl apply -f https://github.com/kserve/kserve/releases/download/v0.13.0/kserve-cluster-resources.yaml
+    kubectl apply -f https://github.com/kserve/kserve/releases/download/v{{  kserve_release_version }}/kserve-cluster-resources.yaml
     ```
 
 **ii. Change default deployment mode and ingress option**
@@ -72,4 +72,3 @@ then modify the `ingressClassName` in `ingress` section to point to `IngressClas
         "ingressClassName" : "your-ingress-class",
     }
     ```
-

--- a/docs/admin/serverless/serverless.md
+++ b/docs/admin/serverless/serverless.md
@@ -7,7 +7,7 @@ Kubernetes version.
 
 ## Recommended Version Matrix
 | Kubernetes Version | Recommended Istio Version | Recommended Knative Version |
-|:-------------------|:--------------------------|:----------------------------|
+| :----------------- | :------------------------ | :-------------------------- |
 | 1.27               | 1.18,1.19                 | 1.10,1.11                   |
 | 1.28               | 1.19,1.20                 | 1.11,1.12.4                 |
 | 1.29               | 1.20,1.21                 | 1.12.4,1.13.1               |
@@ -35,14 +35,14 @@ The minimally required Cert Manager version is 1.9.0 and you can refer to [Cert 
 ## 4. Install KServe
 === "kubectl"
     ```bash
-    kubectl apply -f https://github.com/kserve/kserve/releases/download/v0.13.0/kserve.yaml
+    kubectl apply -f https://github.com/kserve/kserve/releases/download/v{{  kserve_release_version }}/kserve.yaml
     ```
 
 ## 5. Install KServe Built-in ClusterServingRuntimes
-
+{{ kserve_release_version }}
 === "kubectl"
     ```bash
-    kubectl apply -f https://github.com/kserve/kserve/releases/download/v0.13.0/kserve-cluster-resources.yaml
+    kubectl apply -f https://github.com/kserve/kserve/releases/download/v{{ kserve_release_version }}/kserve-cluster-resources.yaml
     ```
 
 !!! note

--- a/docs/get_started/README.md
+++ b/docs/get_started/README.md
@@ -42,6 +42,6 @@ The [Kubernetes CLI (`kubectl`)](https://kubernetes.io/docs/tasks/tools/install-
 
     or install via our published Helm Charts:
    ```bash
-   helm install kserve-crd oci://ghcr.io/kserve/charts/kserve-crd --version v0.13.0
-   helm install kserve oci://ghcr.io/kserve/charts/kserve --version v0.13.0
+   helm install kserve-crd oci://ghcr.io/kserve/charts/kserve-crd --version v{{  kserve_release_version }}
+   helm install kserve oci://ghcr.io/kserve/charts/kserve --version v{{  kserve_release_version }}
    ```

--- a/docs/modelserving/v1beta1/triton/huggingface/README.md
+++ b/docs/modelserving/v1beta1/triton/huggingface/README.md
@@ -45,7 +45,7 @@ Create an InferenceService with triton predictor by specifying the `storageUri` 
           - --model_id=bert-base-uncased
           - --predictor_protocol=v2
           - --tensor_input_names=input_ids
-          image: kserve/huggingfaceserver:v0.13.0
+          image: kserve/huggingfaceserver:v{{  kserve_release_version }}
           name: kserve-container
           resources:
             limits:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -176,6 +176,8 @@ copyright: "Copyright © 2021 The KServe Authors"
 
 plugins:
   - search
+  - macros:
+      on_undefined: keep
   - mkdocstrings:
       default_handler: python
       handlers:
@@ -191,8 +193,10 @@ plugins:
         filter: ""
         syntaxHighlightTheme: monokai
         tryItOutEnabled: true
+       
 
 extra:
+  kserve_release_version: 0.13.0
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/kserve


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`kserve/website` GitHub repository](https://github.com/kserve/website).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/help/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/help/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the KServe blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, add the corresponding "cherrypick-0.X"
label to the original PR; for example, "cherrypick-0.12".
Best practice is to open a PR for the cherry-pick yourself after your original PR has been merged
into the main branch.
After the cherry-pick PR has merged, remove the cherry-pick label from the original PR.

For all resources for contributing to the KServe documentation, see the
[KServe contributor's guide](/docs/help/contributor/mkdocs-contributor-guide.md).

 -->

"Fixes #issue-number" or "Add description of the problem this PR solves"

## Proposed Changes <!-- Describe the changes the PR makes. -->

- I proposed to use macro global variable for kserve-release-version because I noticed that this value is used in several files.

