### PR TITLE
Separate Secret and ISVC YAML for Hugging Face runtime example

### DIFF
--- a/docs/modelserving/v1beta1/llm/huggingface/text_generation/README.md
+++ b/docs/modelserving/v1beta1/llm/huggingface/text_generation/README.md
@@ -13,6 +13,7 @@ If the model is not supported by vLLM, KServe falls back to HuggingFace backend 
 Create a secret with the Hugging Face token.
 
 === "Yaml"
+
     ```yaml
     apiVersion: v1
     kind: Secret

--- a/docs/modelserving/v1beta1/llm/huggingface/text_generation/README.md
+++ b/docs/modelserving/v1beta1/llm/huggingface/text_generation/README.md
@@ -23,6 +23,8 @@ Create a secret with the Hugging Face token.
         HF_TOKEN: <token>
     ```
 
+Then create the inference service.
+
 === "Yaml"
 
     ```yaml
@@ -190,6 +192,7 @@ Create a secret with the Hugging Face token.
     stringData:
         HF_TOKEN: <token>
     ```
+Then create the inference service.
 
 === "Yaml"
 


### PR DESCRIPTION
These two YAMLs are currently incorrectly rendered on the website as two separate tabs: 
![image](https://github.com/user-attachments/assets/da943885-4f27-42b6-96cb-2c548bd0fcba)
