### PR TITLE
fix: correct the {{ escaping to prevent issue with mkdocs

### DIFF
--- a/docs/get_started/first_isvc.md
+++ b/docs/get_started/first_isvc.md
@@ -164,7 +164,7 @@ Depending on your setup, use one of the following commands to curl the `Inferenc
     kubectl edit cm config-domain --namespace knative-serving
     ```
 
-    Now in your editor, change example.com to {{external-ip}}.xip.io (make sure to replace {{external-ip}} with the IP you found earlier).
+    Now in your editor, change example.com to {{ '{{' }}external-ip{{ '}}' }}.xip.io (make sure to replace {{ '{{' }}external-ip{{ '}}' }} with the IP you found earlier).
 
     With the change applied you can now directly curl the URL
     ```bash


### PR DESCRIPTION
There is `Macro Rendering Error` in [First InferenceService](https://kserve.github.io/website/master/get_started/first_isvc/) page. It happened because jinja failed to render `{{` and we need to use `{{ '{{' }}`.