### PR TITLE
doc for return response headers from v1 and v2 endpoints

### DIFF
--- a/docs/modelserving/v1beta1/custom/custom_model/README.md
+++ b/docs/modelserving/v1beta1/custom/custom_model/README.md
@@ -27,7 +27,7 @@ from kserve import logging
 
 class AlexNetModel(Model):
     def __init__(self, name: str):
-       super().__init__(name)
+       super().__init__(name, return_response_headers=True)
        self.name = name
        self.load()
 
@@ -36,7 +36,12 @@ class AlexNetModel(Model):
         self.model.eval()
         self.ready = True
 
-    def predict(self, payload: Dict, headers: Dict[str, str] = None) -> Dict:
+    def predict(
+        self, 
+        payload: Dict, 
+        headers: Dict[str, str] = None, 
+        response_headers: Dict[str, str] = None,
+    ) -> Dict:
         img_data = payload["instances"][0]["image"]["b64"]
         raw_img_data = base64.b64decode(img_data)
         input_image = Image.open(io.BytesIO(raw_img_data))
@@ -64,6 +69,9 @@ if __name__ == "__main__":
     model = AlexNetModel(args.model_name)
     ModelServer().start([model])
 ```
+
+!!! note
+    `return_response_headers=True` will be used to return response headers from v1 and v2 endpoints
 
 ### Build Custom Serving Image with BuildPacks
 [Buildpacks](https://buildpacks.io/) allows you to transform your inference code into images that can be deployed on KServe without

--- a/docs/modelserving/v1beta1/custom/custom_model/README.md
+++ b/docs/modelserving/v1beta1/custom/custom_model/README.md
@@ -58,6 +58,13 @@ class AlexNetModel(Model):
         values, top_5 = torch.topk(output, 5)
         result = values.flatten().tolist()
         response_id = generate_uuid()
+
+        # Update the response_headers argument with your header values
+        # Example: 
+        res_headers = {"example_header": "my_header"}
+        if response_headers is not None:
+            response_headers.update(res_headers) 
+            
         return {"predictions": result}
 
 parser = argparse.ArgumentParser(parents=[kserve.model_server.parser])
@@ -71,7 +78,7 @@ if __name__ == "__main__":
 ```
 
 !!! note
-    `return_response_headers=True` will be used to return response headers from v1 and v2 endpoints
+    `return_response_headers=True` can be added to return response headers for v1 and v2 endpoints
 
 ### Build Custom Serving Image with BuildPacks
 [Buildpacks](https://buildpacks.io/) allows you to transform your inference code into images that can be deployed on KServe without


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`kserve/website` GitHub repository](https://github.com/kserve/website).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/help/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/help/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the KServe blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, add the corresponding "cherrypick-0.X"
label to the original PR; for example, "cherrypick-0.12".
Best practice is to open a PR for the cherry-pick yourself after your original PR has been merged
into the main branch.
After the cherry-pick PR has merged, remove the cherry-pick label from the original PR.

For all resources for contributing to the KServe documentation, see the
[KServe contributor's guide](/docs/help/contributor/mkdocs-contributor-guide.md).

 -->

"Fixes #issue-number" or "Add description of the problem this PR solves"

## Proposed Changes <!-- Describe the changes the PR makes. -->

-
-
-

