### PR TITLE
fix: bad formatting of lt/gt in v2_protocol.md

### DIFF
--- a/docs/modelserving/data_plane/v2_protocol.md
+++ b/docs/modelserving/data_plane/v2_protocol.md
@@ -23,12 +23,12 @@ See also: The HTTP/REST endpoints are defined in [rest_predict_v2.yaml](https://
 
 | API  | Verb | Path | Request Payload | Response Payload | 
 | ------------- | ------------- | ------------- | ------------- | ------------- |
-| Inference | POST | v2/models/<model_name>[/versions/\<model_version\>]/infer | [$inference_request](#inference-request-json-object) | [$inference_response](#inference-response-json-object) |
+| Inference | POST | v2/models/\<model_name\>[/versions/\<model_version\>]/infer | [$inference_request](#inference-request-json-object) | [$inference_response](#inference-response-json-object) |
 | Model Metadata | GET | v2/models/\<model_name\>[/versions/\<model_version\>] | | [$metadata_model_response](#model-metadata-response-json-object) | 
 | Server Ready | GET | v2/health/ready | | [$ready_server_response](#server-ready-response-json-object) | 
 | Server Live | GET | v2/health/live | | [$live_server_response](#server-live-response-json-objet)| 
 | Server Metadata | GET | v2 | | [$metadata_server_response](#server-metadata-response-json-object) |
-| Model Ready| GET   | v2/models/\<model_name\>[/versions/<model_version>]/ready |  | [$ready_model_response](#model-ready-response-json-object) |
+| Model Ready| GET   | v2/models/\<model_name\>[/versions/\<model_version\>]/ready |  | [$ready_model_response](#model-ready-response-json-object) |
 
 ** path contents in `[]` are optional
 


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`kserve/website` GitHub repository](https://github.com/kserve/website).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/help/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/help/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the KServe blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, add the corresponding "cherrypick-0.X"
label to the original PR; for example, "cherrypick-0.12".
Best practice is to open a PR for the cherry-pick yourself after your original PR has been merged
into the main branch.
After the cherry-pick PR has merged, remove the cherry-pick label from the original PR.

For all resources for contributing to the KServe documentation, see the
[KServe contributor's guide](/docs/help/contributor/mkdocs-contributor-guide.md).

 -->

fix: bad formatting of lt/gt in v2_protocol.md

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Fix mistakes that resulted in rendering these incorrect URL paths: v2/models/[/versions/<model_version>]/infer
v2/models/<model_name>[/versions/]/ready

