### PR TITLE
logger feature can work without knative, in my testing.

### DIFF
--- a/docs/modelserving/logger/logger.md
+++ b/docs/modelserving/logger/logger.md
@@ -24,6 +24,9 @@ spec:
 kubectl create -f message-dumper.yaml
 ```
 
+!!! Note
+    You can create your own message-dumper service, in order to print during testing. Knative is not necessary for this feature.
+
 ### Create an InferenceService with Logger
 
 Create a sklearn predictor with the logger which points at the message dumper url.


### PR DESCRIPTION
<!-- General PR guidelines:
pls view https://github.com/kserve/kserve/issues/4128
logger works without knative, current docs may bring confuse.

Most PRs should be opened against the main branch in the
[`kserve/website` GitHub repository](https://github.com/kserve/website).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/help/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/help/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the KServe blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, add the corresponding "cherrypick-0.X"
label to the original PR; for example, "cherrypick-0.12".
Best practice is to open a PR for the cherry-pick yourself after your original PR has been merged
into the main branch.
After the cherry-pick PR has merged, remove the cherry-pick label from the original PR.

For all resources for contributing to the KServe documentation, see the
[KServe contributor's guide](/docs/help/contributor/mkdocs-contributor-guide.md).

 -->

"Fixes #issue-number" or "Add description of the problem this PR solves"

## Proposed Changes <!-- Describe the changes the PR makes. -->

-
-
-
pls view https://github.com/kserve/kserve/issues/4128
logger works without knative, current docs may bring confuse.
