### PR TITLE
fix gateway yaml format and missing label

### DIFF
--- a/docs/admin/gatewayapi_migration.md
+++ b/docs/admin/gatewayapi_migration.md
@@ -129,7 +129,7 @@ kubectl rollout restart deployment kserve-controller-manager -n kserve
 If you are using a cloud provider, you may need to configure the external traffic to the LoadBalancer service created in [step 4](#4-create-gateway-resource).
 
 ```shell
-kubectl get svc kserve-ingress-gateway -l  -A
+kubectl get svc -l serving.kserve.io/gateway=kserve-ingress-gateway -A
 ```
 
 ## 8. Verify the Gateway API configuration

--- a/docs/admin/kubernetes_deployment.md
+++ b/docs/admin/kubernetes_deployment.md
@@ -55,9 +55,9 @@ The minimally required Cert Manager version is 1.15.0 and you can refer to [Cert
         - name: http
           protocol: HTTP
           port: 80
-            allowedRoutes:
-              namespaces:
-                from: All
+          allowedRoutes:
+            namespaces:
+              from: All
         - name: https
           protocol: HTTPS
           port: 443
@@ -70,9 +70,9 @@ The minimally required Cert Manager version is 1.15.0 and you can refer to [Cert
           allowedRoutes:
             namespaces:
               from: All
-        infrastructure:
-        labels:
-          serving.kserve.io/gateway: kserve-ingress-gateway
+      infrastructure:
+      labels:
+        serving.kserve.io/gateway: kserve-ingress-gateway
     ```
     !!! note
         KServe comes with a default `Gateway` named kserve-ingress-gateway. You can enable the default gateway by setting Helm value `kserve.controller.gateway.ingressGateway.createGateway` to `true`.


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`kserve/website` GitHub repository](https://github.com/kserve/website).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/help/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/help/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the KServe blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, add the corresponding "cherrypick-0.X"
label to the original PR; for example, "cherrypick-0.12".
Best practice is to open a PR for the cherry-pick yourself after your original PR has been merged
into the main branch.
After the cherry-pick PR has merged, remove the cherry-pick label from the original PR.

For all resources for contributing to the KServe documentation, see the
[KServe contributor's guide](/docs/help/contributor/mkdocs-contributor-guide.md).

 -->

"Fixes #issue-number" or "Add description of the problem this PR solves"
File (gatewayapi_migration) missed a label name to get gate
## Proposed Changes <!-- Describe the changes the PR makes. -->

-
```
kubectl get svc kserve-ingress-gateway -l  -A
``` 
to 
```
kubectl get svc -l serving.kserve.io/gateway=kserve-ingress-gateway -A
```
-
-

