### PR TITLE
docs: update local model cache documentation for clarity and configuration details

### DIFF
--- a/docs/modelserving/storage/modelcache/localmodel.md
+++ b/docs/modelserving/storage/modelcache/localmodel.md
@@ -3,49 +3,32 @@
 By caching LLM models locally, the `InferenceService` startup time can be greatly improved. For deployments with more than one replica,
 the local persistent volume can serve multiple pods with the warmed up model cache.
 
-- `LocalModelCache` is a KServe custom resource to specify which model from persistent storage to cache on local storage of the kubernetes node. 
+- `LocalModelCache` is a KServe custom resource to specify which model from persistent storage to cache on local storage of the Kubernetes node. 
 - `LocalModelNodeGroup` is a KServe custom resource to manage the node group for caching the models and the local persistent storage.
 - `LocalModelNode` is a KServe custom resource to track the status of the models cached on given local node.
 
-In this example, we demonstrate how you can cache the models using Kubernetes nodes' local disk NVMe volumes from HF hub.
+In this example, we demonstrate how you can cache the models using Kubernetes node's local disk NVMe volumes from HF hub.
 
-## Create the LocalModelNodeGroup
+## Enable Local Model Cache
+By default, the model caching is disabled in KServe. To enable it, you need to set the `enabled` field to `true` in the `localModel` section of `inferenceservice-config` ConfigMap.
 
-Create the `LocalModelNodeGroup` using the local persistent volume with specified local NVMe volume path.
+```bash
+kubectl edit configmap inferenceservice-config -n kserve
+```
 
-- The `storageClassName` should be set to `local-storage`.
-- The `nodeAffinity` should be specified which nodes to cache the model using node selector.
-- Local path should be specified on PV as the local storage to cache the models.
-```yaml
-apiVersion: serving.kserve.io/v1alpha1
-kind: LocalModelNodeGroup
-metadata:
-  name: workers
-spec:
-  storageLimit: 1.7T
-  persistentVolumeClaimSpec:
-    accessModes:
-      - ReadWriteOnce
-    resources:
-      requests:
-        storage: 1700G
-    storageClassName: local-storage
-    volumeMode: Filesystem
-    volumeName: models
-  persistentVolumeSpec:
-    accessModes:
-      - ReadWriteOnce
-    volumeMode: Filesystem
-    capacity:
-      storage: 1700G
-    local:
-      path: /models
-    nodeAffinity:
-       required:
-         nodeSelectorTerms:
-           - key: nvidia.com/gpu-product
-             values:
-               - NVIDIA-A100-SXM4-80GB
+```yaml hl_lines="3"
+ localModel: |-
+    {
+      "enabled": true,
+      "jobNamespace": "kserve-localmodel-jobs",
+      "defaultJobImage" : "kserve/storage-initializer:latest",
+      "fsGroup": 1000,
+      "localModelAgentImage": "kserve/kserve-localmodelnode-agent:latest",
+      "localModelAgentCpuRequest": "100m",
+      "localModelAgentMemoryRequest": "200Mi",
+      "localModelAgentCpuLimit": "100m",
+      "localModelAgentMemoryLimit": "300Mi"
+    }
 ```
 
 ## Configure Local Model Download Job Namespace
@@ -64,6 +47,11 @@ type: Opaque
 stringData:
   HF_TOKEN: xxxx # fill in the hf hub token
 ```
+
+!!! Tip
+    Model download job namespace can be configured in the `inferenceservice-config` ConfigMap by editing the `jobNamespace` value in the `localModel` section.
+    The default namespace is `kserve-localmodel-jobs`.
+
 
 Create the HF Hub cluster storage container to refer to the HF Hub secret.
 
@@ -95,6 +83,60 @@ spec:
   workloadType: localModelDownloadJob
 ```
 
+## Create the LocalModelNodeGroup
+
+Create the `LocalModelNodeGroup` using the local persistent volume with specified local NVMe volume path.
+
+- The `storageClassName` should be set to `local-storage`.
+- The `nodeAffinity` should be specified which nodes to cache the model using node selector.
+- Local path should be specified on PV as the local storage to cache the models.
+
+```yaml
+apiVersion: serving.kserve.io/v1alpha1
+kind: LocalModelNodeGroup
+metadata:
+  name: workers
+spec:
+  storageLimit: 1.7T
+  persistentVolumeClaimSpec:
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1700G
+    storageClassName: local-storage
+    volumeMode: Filesystem
+    volumeName: models
+  persistentVolumeSpec:
+    accessModes:
+      - ReadWriteOnce
+    volumeMode: Filesystem
+    capacity:
+      storage: 1700G
+    local:
+      path: /models
+    storageClassName: local-storage
+    nodeAffinity:
+      required:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: nvidia.com/gpu-product
+                operator: In
+                values:
+                  - NVIDIA-A100-SXM4-80GB
+```
+
+After the `LocalModelNodeGroup` is created, KServe creates an agent DaemonSet on each node (nodes matching the `nodeAffinity` specified in LocalModelNodeGroup) in the `kserve` namespace to monitor the local model cache lifecycle.
+
+```bash
+kubectl get daemonset -n kserve workers-agent
+```
+
+!!! success Expected Output
+    ```bash
+    NAME            DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR        AGE
+    workers-agent   1         1         1       1            1           <none>               5d17h
+    ```
 
 ## Create the LocalModelCache
 
@@ -110,26 +152,34 @@ kind: LocalModelCache
 metadata:
   name: meta-llama3-8b-instruct
 spec:
-  sourceModelUri: hf://meta-llama/meta-llama-3-8b-instruct
+  sourceModelUri: 'hf://meta-llama/meta-llama-3-8b-instruct'
   modelSize: 10Gi
-  nodeGroups: 
-  - workers
+  nodeGroups:
+    - workers
 ```
 
 After `LocalModelCache` is created, KServe creates the download jobs on each node in the group to cache the model in local storage.
 
 ```bash
 kubectl get jobs meta-llama3-8b-instruct-kind-worker  -n kserve-localmodel-jobs
-NAME                                       STATUS     COMPLETIONS   DURATION   AGE
-meta-llama3-8b-instruct-gptq-kind-worker   Complete   1/1           4m21s      5d17h
 ```
+
+!!! success Expected Output
+    ```bash
+       NAME                                       STATUS     COMPLETIONS   DURATION   AGE
+       meta-llama3-8b-instruct-gptq-kind-worker   Complete   1/1           4m21s      5d17h
+    ```
 
 The download job is created using the provisioned PV/PVC.
 ```bash
 kubectl get pvc meta-llama3-8b-instruct  -n kserve-localmodel-jobs 
-NAME                      STATUS   VOLUME                             CAPACITY   ACCESS MODES   STORAGECLASS    VOLUMEATTRIBUTESCLASS   AGE
-meta-llama3-8b-instruct   Bound    meta-llama3-8b-instruct-download   10Gi       RWO            local-storage   <unset>                 9h
 ```
+
+!!! success Expected Output
+    ```
+    NAME                      STATUS   VOLUME                             CAPACITY   ACCESS MODES   STORAGECLASS    VOLUMEATTRIBUTESCLASS   AGE
+    meta-llama3-8b-instruct   Bound    meta-llama3-8b-instruct-download   10Gi       RWO            local-storage   <unset>                 9h
+    ```
 
 ## Check the LocalModelCache Status
 
@@ -160,27 +210,25 @@ status:
 ```bash
 kubectl get localmodelnode kind-worker -oyaml
 ```
-
-```yaml
-apiVersion: serving.kserve.io/v1alpha1
-kind: LocalModelNode
-metadata:
-  name: kind-worker
-spec:
-  localModels:
-    - modelName: meta-llama3-8b-instruct
-      sourceModelUri: hf://meta-llama/meta-llama-3-8b-instruct
-status:
-  modelStatus:
-    meta-llama3-8b-instruct: ModelDownloaded
-```
+!!! success Expected Output
+    ```yaml
+    apiVersion: serving.kserve.io/v1alpha1
+    kind: LocalModelNode
+    metadata:
+      name: kind-worker
+    spec:
+      localModels:
+        - modelName: meta-llama3-8b-instruct
+          sourceModelUri: hf://meta-llama/meta-llama-3-8b-instruct
+    status:
+      modelStatus:
+        meta-llama3-8b-instruct: ModelDownloaded
+    ```
 
 ## Deploy InferenceService using the LocalModelCache
 
 Finally you can deploy the LLMs with `InferenceService` using the local model cache if the model has been previously cached
 using the `LocalModelCache` resource by matching the model storage URI.
-
-The model cache is currently disabled by default. To enable, you need to modify the `localmodel.enabled` field on the `inferenceservice-config` ConfigMap.
 
 === "Yaml"
 
@@ -197,7 +245,6 @@ The model cache is currently disabled by default. To enable, you need to modify 
             name: huggingface
           args:
             - --model_name=llama3
-            - --model_id=meta-llama/meta-llama-3-8b-instruct
           storageUri: hf://meta-llama/meta-llama-3-8b-instruct
           resources:
             limits:

--- a/docs/modelserving/storage/modelcache/localmodel.md
+++ b/docs/modelserving/storage/modelcache/localmodel.md
@@ -7,7 +7,7 @@ the local persistent volume can serve multiple pods with the warmed up model cac
 - `LocalModelNodeGroup` is a KServe custom resource to manage the node group for caching the models and the local persistent storage.
 - `LocalModelNode` is a KServe custom resource to track the status of the models cached on given local node.
 
-In this example, we demonstrate how you can cache the models using Kubernetes node's local disk NVMe volumes from HF hub.
+In this example, we demonstrate how you can cache the models using Kubernetes nodes' local disk NVMe volumes from HF hub.
 
 ## Enable Local Model Cache
 By default, the model caching is disabled in KServe. To enable it, you need to set the `enabled` field to `true` in the `localModel` section of `inferenceservice-config` ConfigMap.


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`kserve/website` GitHub repository](https://github.com/kserve/website).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/help/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/help/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the KServe blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, add the corresponding "cherrypick-0.X"
label to the original PR; for example, "cherrypick-0.12".
Best practice is to open a PR for the cherry-pick yourself after your original PR has been merged
into the main branch.
After the cherry-pick PR has merged, remove the cherry-pick label from the original PR.

For all resources for contributing to the KServe documentation, see the
[KServe contributor's guide](/docs/help/contributor/mkdocs-contributor-guide.md).

 -->

Fixes kserve/kserve#4462

## Proposed Changes <!-- Describe the changes the PR makes. -->

- update local model cache documentation for clarity and configuration details

