### PR TITLE
4609 - Rename deploy modes to match changes in kserve

### DIFF
--- a/docs/admin-guide/configurations.md
+++ b/docs/admin-guide/configurations.md
@@ -602,7 +602,7 @@ kind: InferenceService
 metadata:
   name: my-inferenceservice
   annotations:
-    serving.kserve.io/deploymentMode: "RawDeployment"
+    serving.kserve.io/deploymentMode: "Standard"
 spec:
   predictor:
     model:
@@ -619,8 +619,8 @@ The default deployment mode for KServe resources.
 
 - **Global key:** `defaultDeploymentMode`  
 - **Per-service annotation key:** `serving.kserve.io/deploymentMode`
-- **Possible values:** `"Serverless"`, `"RawDeployment"`, `"ModelMesh"`
-- **Default:** `"Serverless"`
+- **Possible values:** `"Knative"`, `"Standard"`, `"ModelMesh"`
+- **Default:** `"Knative"`
 
 ## InferenceService Configuration
 
@@ -1147,7 +1147,7 @@ Enables Prometheus scraping annotations on pods. If true, prometheus annotations
 
 ## OpenTelemetry Collector Configuration
 
-Configures OpenTelemetry metrics collection for autoscaling with KEDA in Raw deployment mode.
+Configures OpenTelemetry metrics collection for autoscaling with KEDA in Standard mode.
 For more details, see the [autoscaling with KEDA documentation](../model-serving/generative-inference/autoscaling/autoscaling.md).
 
 <Tabs>
@@ -1345,7 +1345,7 @@ data:
 
 ### Service Cluster IP None
 
-Controls whether services should have clusterIP set to None. This is useful for creating headless services where you want to manage the service endpoints manually. This configuration is only applicable to Raw deployment mode.
+Controls whether services should have clusterIP set to None. This is useful for creating headless services where you want to manage the service endpoints manually. This configuration is only applicable to Standard mode.
 
 - **Global key:** `serviceClusterIPNone`
 - **Per-service annotation key:** Not supported
@@ -1389,7 +1389,7 @@ Configures autoscaling settings for InferenceServices.
 
 ### Autoscaler Class
 
-The type of the autoscaler to use for scaling InferenceServices. This configuration is only applicable to Raw deployment mode. Prefer "none" when disabling KServe-managed autoscaling entirely. Use "external" only when another controller will manage the HPA.
+The type of the autoscaler to use for scaling InferenceServices. This configuration is only applicable to Standard mode. Prefer "none" when disabling KServe-managed autoscaling entirely. Use "external" only when another controller will manage the HPA.
 
 - **Global key:** Not supported
 - **Per-service key:** `serving.kserve.io/autoscaler-class`

--- a/docs/admin-guide/configurations.md
+++ b/docs/admin-guide/configurations.md
@@ -590,7 +590,7 @@ metadata:
 data:
   deploy: |-
     {
-      "defaultDeploymentMode": "Serverless"
+      "defaultDeploymentMode": "Knative"
     }
 ```
 </TabItem>

--- a/docs/admin-guide/kubernetes-deployment.md
+++ b/docs/admin-guide/kubernetes-deployment.md
@@ -8,9 +8,9 @@ import TabItem from '@theme/TabItem';
 
 # Kubernetes Deployment Installation
 
-KServe supports `RawDeployment` mode to enable `InferenceService` deployment for both **Predictive Inference** and **Generative Inference** workloads with **minimal dependencies** on Kubernetes resources: [`Deployment`](https://kubernetes.io/docs/concepts/workloads/controllers/deployment), [`Service`](https://kubernetes.io/docs/concepts/services-networking/service), [`Ingress`](https://kubernetes.io/docs/concepts/services-networking/ingress) / [`Gateway API`](https://kubernetes.io/docs/concepts/services-networking/gateway/) and [`Horizontal Pod Autoscaler`](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale).
+KServe supports `Standard` mode to enable `InferenceService` deployment for both **Predictive Inference** and **Generative Inference** workloads with **minimal dependencies** on Kubernetes resources: [`Deployment`](https://kubernetes.io/docs/concepts/workloads/controllers/deployment), [`Service`](https://kubernetes.io/docs/concepts/services-networking/service), [`Ingress`](https://kubernetes.io/docs/concepts/services-networking/ingress) / [`Gateway API`](https://kubernetes.io/docs/concepts/services-networking/gateway/) and [`Horizontal Pod Autoscaler`](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale).
 
-Compared to `Serverless` mode which depends on Knative for request-driven autoscaling, in `RawDeployment` mode [KEDA](https://keda.sh) can be installed optionally to enable autoscaling based on any custom metrics. Note that `Scale from Zero` is currently not supported in `RawDeployment` mode for HTTP requests.
+Compared to `Knative` mode which depends on Knative for request-driven autoscaling, in `Standard` mode [KEDA](https://keda.sh) can be installed optionally to enable autoscaling based on any custom metrics. Note that `Scale from Zero` is currently not supported in `Standard` mode for HTTP requests.
 
 ## Installation Requirements
 
@@ -27,14 +27,14 @@ KServe has the following minimum requirements:
 ## Deployment Considerations
 
 ### For Generative Inference
-Raw Kubernetes deployment is the **recommended approach** for generative inference workloads because it provides:
+Standard Kubernetes deployment is the **recommended approach** for generative inference workloads because it provides:
 - Full control over resource allocation for GPU-accelerated models
 - Better handling of long-running inference requests
 - More predictable scaling behavior for resource-intensive workloads
 - Support for streaming responses with appropriate networking configuration
 
 ### For Predictive Inference
-Raw Kubernetes deployment is suitable for predictive inference workloads when:
+Standard Kubernetes deployment is suitable for predictive inference workloads when:
 - You need direct control over Kubernetes resources
 - Your models require specific resource configurations
 - You want to use standard Kubernetes scaling mechanisms
@@ -144,7 +144,7 @@ Istio ingress is recommended, but you can choose to install with other [Ingress 
 ### 3. Install KServe
 
 :::note
-The default KServe deployment mode is `Serverless` which depends on Knative. The following step changes the default deployment mode to `RawDeployment` before installing KServe.
+The default KServe deployment mode is `Knative` which depends on Knative. The following step changes the default deployment mode to `Standard` before installing KServe.
 :::
 
 <Tabs>
@@ -158,11 +158,11 @@ helm install kserve-crd oci://ghcr.io/kserve/charts/kserve-crd --version v0.15.0
 
 2. Install KServe Resources
 
-Set the `kserve.controller.deploymentMode` to `RawDeployment` and configure the Gateway API:
+Set the `kserve.controller.deploymentMode` to `Standard` and configure the Gateway API:
 
 ```bash
 helm install kserve oci://ghcr.io/kserve/charts/kserve --version v0.15.0 \
-  --set kserve.controller.deploymentMode=RawDeployment \
+  --set kserve.controller.deploymentMode=Standard \
   --set kserve.controller.gateway.ingressGateway.enableGatewayApi=true \
   --set kserve.controller.gateway.ingressGateway.kserveGateway=kserve/kserve-ingress-gateway
 ```
@@ -185,10 +185,10 @@ kubectl apply --server-side -f https://github.com/kserve/kserve/releases/downloa
 
 3. Change default deployment mode and ingress option
 
-First in the ConfigMap `inferenceservice-config` modify the `defaultDeploymentMode` to `RawDeployment`:
+First in the ConfigMap `inferenceservice-config` modify the `defaultDeploymentMode` to `Standard`:
 
 ```bash
-kubectl patch configmap/inferenceservice-config -n kserve --type=strategic -p '{"data": {"deploy": "{\"defaultDeploymentMode\": \"RawDeployment\"}"}}'
+kubectl patch configmap/inferenceservice-config -n kserve --type=strategic -p '{"data": {"deploy": "{\"defaultDeploymentMode\": \"Standard\"}"}}'
 ```
 
 Then enable Gateway API and configure the Gateway:
@@ -208,11 +208,11 @@ helm install kserve-crd oci://ghcr.io/kserve/charts/kserve-crd --version v0.15.0
 
 2. Install KServe Resources
 
-Set the `kserve.controller.deploymentMode` to `RawDeployment` and configure the Ingress class:
+Set the `kserve.controller.deploymentMode` to `Standard` and configure the Ingress class:
 
 ```bash
 helm install kserve oci://ghcr.io/kserve/charts/kserve --version v0.15.0 \
-  --set kserve.controller.deploymentMode=RawDeployment \
+  --set kserve.controller.deploymentMode=Standard \
   --set kserve.controller.gateway.ingressGateway.className=istio
 ```
 
@@ -234,10 +234,10 @@ kubectl apply --server-side -f https://github.com/kserve/kserve/releases/downloa
 
 3. Change default deployment mode and ingress option
 
-First in the ConfigMap `inferenceservice-config` modify the `defaultDeploymentMode` to `RawDeployment`:
+First in the ConfigMap `inferenceservice-config` modify the `defaultDeploymentMode` to `Standard`:
 
 ```bash
-kubectl patch configmap/inferenceservice-config -n kserve --type=strategic -p '{"data": {"deploy": "{\"defaultDeploymentMode\": \"RawDeployment\"}"}}'
+kubectl patch configmap/inferenceservice-config -n kserve --type=strategic -p '{"data": {"deploy": "{\"defaultDeploymentMode\": \"Standard\"}"}}'
 ```
 
 Then configure the Ingress class:
@@ -251,9 +251,9 @@ kubectl patch configmap/inferenceservice-config -n kserve --type=strategic -p '{
 
 ## Features
 
-### Raw Deployment Mode
+### Standard Mode
 
-In raw deployment mode, KServe creates:
+In standard mode, KServe creates:
 - Kubernetes Deployments instead of Knative Services
 - Standard Kubernetes Services for networking
 - Ingress resources for external access

--- a/docs/admin-guide/overview.md
+++ b/docs/admin-guide/overview.md
@@ -32,7 +32,7 @@ Generative inference workloads involve models that generate new content (text, i
 - Process streaming responses
 - Have higher memory requirements
 
-**Recommended deployment option**: For generative inference workloads, the **Raw Kubernetes Deployment** approach is recommended as it provides the most control over resource allocation and scaling. Gateway API is particularly recommended for generative inference to handle streaming responses effectively.
+**Recommended deployment option**: For generative inference workloads, the **Standard Kubernetes Deployment** approach is recommended as it provides the most control over resource allocation and scaling. Gateway API is particularly recommended for generative inference to handle streaming responses effectively.
 
 ### Predictive Inference
 
@@ -45,59 +45,59 @@ Predictive inference workloads involve models that predict specific values or cl
 - Return fixed-size responses
 
 **Available deployment options**: For predictive inference workloads, KServe offers multiple deployment options:
-- **Raw Kubernetes Deployment**: For direct control over resources
-- **Serverless Deployment**: For scale to zero capabilities and cost optimization
+- **Standard Kubernetes Deployment**: For direct control over resources
+- **Knative Deployment**: For scale to zero capabilities and cost optimization
 - **ModelMesh Deployment**: For high-density, multi-model scenarios
 
 ## Deployment Options
 
-### Raw Kubernetes Deployment
+### Standard Kubernetes Deployment
 
 :::info
 
-Raw Deployment is applicable for both predictive and generative inference workloads with minimal dependencies.
+Standard Deployment is applicable for both predictive and generative inference workloads with minimal dependencies.
 
 :::
 
-KServe's Raw Deployment mode enables `InferenceService` deployment with minimal dependencies on Kubernetes resources. This approach uses standard Kubernetes resources:
+KServe's Standard Deployment mode enables `InferenceService` deployment with minimal dependencies on Kubernetes resources. This approach uses standard Kubernetes resources:
 
 - `Deployment` for managing container instances
 - `Service` for internal communication
 - `Ingress` / `Gateway API` for external access
 - `Horizontal Pod Autoscaler` for scaling
 
-The Raw Deployment mode offers several advantages:
+The Standard Deployment mode offers several advantages:
 
 - Minimal dependencies on external components
 - Direct use of native Kubernetes resources
 - Flexibility for various deployment scenarios
 - Support for both HTTP and gRPC protocols
 
-Unlike Serverless mode which depends on Knative for request-driven autoscaling, Raw Deployment mode can optionally use [KEDA](https://keda.sh) to enable autoscaling based on custom metrics. However, note that "Scale from Zero" is currently not supported in Raw Deployment mode for HTTP requests.
+Unlike Knative mode which depends on Knative for request-driven autoscaling, Standard Deployment mode can optionally use [KEDA](https://keda.sh) to enable autoscaling based on custom metrics. However, note that "Scale from Zero" is currently not supported in Standard Deployment mode for HTTP requests.
 
-[Learn more about Raw Kubernetes Deployment](./kubernetes-deployment.md)
+[Learn more about Standard Kubernetes Deployment](./kubernetes-deployment.md)
 
-### Serverless Deployment
+### Knative Deployment
 
 :::info
 
-Serverless Deployment is recommended primarily for predictive inference workloads.
+Knative Deployment is recommended primarily for predictive inference workloads.
 
 :::
 
-KServe's Serverless deployment mode leverages Knative to provide request-based autoscaling, including the ability to scale down to zero when there's no traffic. This mode is particularly useful for:
+KServe's Knative deployment mode leverages Knative to provide request-based autoscaling, including the ability to scale down to zero when there's no traffic. This mode is particularly useful for:
 
 - Cost optimization by automatically scaling resources based on demand
 - Environments with varying or unpredictable traffic patterns
 - Scenarios where resources should be freed when not in use
 - Managing multiple model revisions and canary deployments
 
-The Serverless deployment requires:
+The Knative deployment requires:
 - Knative Serving installed in the cluster
 - A compatible networking layer (Istio is recommended, but Kourier is also supported)
 - Cert Manager for webhook certificates
 
-[Learn more about Serverless Deployment](./serverless/serverless.md)
+[Learn more about Knative Deployment](./serverless/serverless.md)
 
 ### ModelMesh Deployment
 
@@ -155,7 +155,7 @@ When administering KServe, consider these best practices:
 
 ### For Predictive Inference
 - **Autoscaling**: Configure appropriate scaling thresholds based on model performance
-- **Resource Efficiency**: Consider Serverless or ModelMesh for cost optimization
+- **Resource Efficiency**: Consider Knative or ModelMesh for cost optimization
 - **Batch Processing**: Configure batch settings for improved throughput when applicable
 
 ## Next Steps
@@ -163,11 +163,11 @@ When administering KServe, consider these best practices:
 Choose one of the detailed guides to proceed with KServe administration based on your inference workload:
 
 ### For Generative Inference
-- [Raw Kubernetes Deployment Guide](./kubernetes-deployment.md)
+- [Standard Kubernetes Deployment Guide](./kubernetes-deployment.md)
 - [Gateway API Migration Guide](./gatewayapi-migration.md)
 
 ### For Predictive Inference
-- [Raw Kubernetes Deployment Guide](./kubernetes-deployment.md)
-- [Serverless Deployment Guide](./serverless/serverless.md)
+- [Standard Kubernetes Deployment Guide](./kubernetes-deployment.md)
+- [Knative Deployment Guide](./serverless/serverless.md)
 - [ModelMesh Deployment Guide](./modelmesh.md)
 - [Gateway API Migration Guide](./gatewayapi-migration.md)

--- a/docs/admin-guide/serverless/kourier-networking/index.md
+++ b/docs/admin-guide/serverless/kourier-networking/index.md
@@ -12,7 +12,7 @@ the following steps show how you can deploy KServe with `Kourier`.
 
 ## Install Kourier Networking Layer
 
-Please refer to the [Serverless Installation Guide](../serverless.md) and change the second step to install `Kourier` instead of `Istio`.
+Please refer to the [Knative Serverless Installation Guide](../serverless.md) and change the second step to install `Kourier` instead of `Istio`.
 
 1. Install the Kourier networking layer:
 

--- a/docs/admin-guide/serverless/serverless.md
+++ b/docs/admin-guide/serverless/serverless.md
@@ -21,7 +21,7 @@ Serverless deployment is particularly well-suited for predictive inference workl
 - Knative's request-based scaling aligns with the traffic patterns of many predictive workloads
 - Canary deployments and revisions enable safe updates to predictive models
 
-For generative inference workloads that typically require GPU resources and have longer processing times, the [Raw Kubernetes Deployment](../kubernetes-deployment.md) approach is recommended.
+For generative inference workloads that typically require GPU resources and have longer processing times, the [Standard Kubernetes Deployment](../kubernetes-deployment.md) approach is recommended.
 
 Kubernetes 1.30 is the minimally required version and please check the following recommended Knative, Istio versions for the corresponding
 Kubernetes version.

--- a/docs/admin-guide/serverless/serverless.md
+++ b/docs/admin-guide/serverless/serverless.md
@@ -1,20 +1,20 @@
 ---
-title: "Serverless Installation Guide"
+title: "Knative Serverless Installation Guide"
 description: "Deploy KServe with request-based autoscaling and scale-to-zero capabilities for predictive inference workloads"
 ---
 
-# Serverless Installation Guide
+# Knative Installation Guide
 
 :::info
-Serverless Deployment is recommended primarily for predictive inference workloads.
+Knative serverless Deployment is recommended primarily for predictive inference workloads.
 :::
 
-KServe Serverless installation enables autoscaling based on request volume and supports scale down to and from zero. It also supports revision management
+KServe Knative serverless installation enables autoscaling based on request volume and supports scale down to and from zero. It also supports revision management
 and canary rollout based on revisions.
 
 ## Applicability for Predictive Inference
 
-Serverless deployment is particularly well-suited for predictive inference workloads because:
+Knative deployment is particularly well-suited for predictive inference workloads because:
 
 - Predictive inference typically has shorter response times that work well with Knative's concurrency model
 - CPU-based models can efficiently scale to zero when not in use

--- a/docs/community/get-involved.md
+++ b/docs/community/get-involved.md
@@ -23,7 +23,7 @@ A good bug report should include:
 - **Description**: Clearly state what you were trying to accomplish and what behavior you observed instead
 - **Versions**: Specify the versions of relevant components:
    - KServe version
-   - Knative version (if using Serverless)
+   - Knative version (if using Knative serverless deployment)
    - Kubeflow version (if used with Kubeflow)
    - Kubernetes version
    - Cloud provider details (if applicable)

--- a/docs/concepts/architecture/control-plane.md
+++ b/docs/concepts/architecture/control-plane.md
@@ -12,7 +12,7 @@ The control plane operates independently from the data plane, allowing for clean
 
 ## Architecture Diagrams
 
-### Raw Deployment Mode with Gateway API (Recommended)
+### Standard Deployment Mode with Gateway API (Recommended)
 
 ```mermaid
 graph TB
@@ -86,7 +86,7 @@ graph TB
     LController -.->|creates| PVC
     LController -.->|creates| PV
 ```          
-### Raw Deployment Mode with Kubernetes Ingress (Limited Functionality)
+### Standard Deployment Mode with Kubernetes Ingress (Limited Functionality)
 
 ```mermaid
 graph TB
@@ -168,7 +168,7 @@ graph TB
     LController -.->|creates| PV
 ```
 
-### Serverless Mode with Knative
+### Knative Mode with Knative
 
 ```mermaid
 graph TB
@@ -185,10 +185,10 @@ graph TB
     classDef modelServerStyle fill:#F5CBA7,stroke:#D35400,color:#000
     classDef featuresStyle fill:#e8f5e8,stroke:#c8e6c9,color:#000
 
-    subgraph ServerlessFeatures["Serverless Features"]
+    subgraph KnativeFeatures["Knative Features"]
         Features[✅ Scale-to-zero<br/>✅ Revision management<br/>✅ Canary deployments<br/>✅ Traffic splitting]:::featuresStyle
     end
-    style ServerlessFeatures fill:none,stroke-dasharray:5
+    style KnativeFeatures fill:none,stroke-dasharray:5
 
     subgraph "UserAppliedResources"["User Applied Resources"]
         subgraph "KServe Resources"
@@ -387,7 +387,7 @@ The KServe Controller Manager is the central component of the control plane, res
 **Architecture Integration:**
 - Operates using the Kubernetes controller pattern with watch-reconcile loops
 - Integrates with admission webhooks for validation and mutation
-- Coordinates with both Raw Deployment and Serverless deployment modes
+- Coordinates with both Standard Deployment and Knative deployment modes
 - Manages model agent containers for enhanced functionality
 
 ### LocalModel Controller (LLM Model Caching)
@@ -468,7 +468,7 @@ While supported for backward compatibility, Kubernetes Ingress has significant l
 - **Multi-Cloud Support**: Works with various cloud provider metrics
 - **Custom Resources**: Uses ScaledObject and ScaledJob custom resources
 
-#### Scale-to-Zero (Serverless Mode Only)
+#### Scale-to-Zero (Knative Mode Only)
 - **Knative Autoscaler (KPA)**: Provides scale-to-zero capabilities
 - **Activator Component**: Handles request queuing and pod activation
 - **Cold Start Optimization**: Minimizes latency when scaling from zero
@@ -512,9 +512,9 @@ While supported for backward compatibility, Kubernetes Ingress has significant l
 
 KServe supports two distinct deployment modes, each with different architectural patterns, capabilities, and use cases. The choice between modes significantly impacts the networking, autoscaling, and operational characteristics of your inference services.
 
-### Raw Deployment Mode (Recommended for LLMs)
+### Standard Deployment Mode (Recommended for LLMs)
 
-Raw Deployment mode uses standard Kubernetes resources and is recommended for most production environments.
+Standard Deployment mode uses standard Kubernetes resources and is recommended for most production environments.
 
 **Architecture Characteristics:**
 - **Standard Kubernetes Deployments**: Uses Deployment, Service, and networking resources
@@ -571,9 +571,9 @@ spec:
       storageUri: gs://kfserving-examples/models/sklearn/1.0/model
 ```
 
-### Serverless Mode (Knative-Based)
+### Knative Mode (Knative-Based)
 
-Serverless mode leverages Knative Serving for event-driven, scale-to-zero capabilities.
+Knative mode leverages Knative Serving for event-driven, scale-to-zero capabilities.
 
 **Architecture Characteristics:**
 - **Knative Service Resources**: Uses Knative Service and Revision resources
@@ -619,7 +619,7 @@ spec:
 
 ### Mode Comparison
 
-| Feature | Raw Deployment | Serverless |
+| Feature | Standard Deployment | Knative |
 |---------|----------------|------------|
 | **Networking** | Gateway API (recommended) / Ingress | Knative Gateway (Istio/Kourier) |
 | **Autoscaling** | HPA + KEDA | Knative Autoscaler (KPA) |
@@ -632,14 +632,14 @@ spec:
 
 ### Choosing the Right Mode
 
-**Choose Raw Deployment when:**
+**Choose Standard Deployment when:**
 - Running production workloads requiring high availability
 - Need predictable performance without cold starts
 - Have existing Kubernetes operational expertise
 - Require advanced networking with Gateway API
 - Need fine-grained control over pod lifecycle
 
-**Choose Serverless when:**
+**Choose Knative when:**
 - Cost optimization through scale-to-zero is important
 - Traffic patterns are variable or unpredictable
 - Development/testing environments with limited resources

--- a/docs/concepts/architecture/index.md
+++ b/docs/concepts/architecture/index.md
@@ -11,9 +11,9 @@ KServe is a cloud-native, Kubernetes-based model serving platform designed for f
 
 KServe offers two powerful deployment modes to fit diverse operational needs:
 
-- **RawDeployment Mode (Highly Recommended for LLM Serving)**: Deploys KServe components as standard Kubernetes Deployments, providing maximum control, reliability, and compatibility with enterprise Kubernetes environments. RawDeployment mode is ideal for users who require predictable scaling, advanced networking, and direct integration with Kubernetes-native tools. This mode is now the preferred choice for most production scenarios, and is especially recommended for serving Large Language Models (LLMs) due to its flexibility and advanced features.
+- **Standard Mode (Highly Recommended for LLM Serving)**: Deploys KServe components as standard Kubernetes Deployments, providing maximum control, reliability, and compatibility with enterprise Kubernetes environments. Standard mode is ideal for users who require predictable scaling, advanced networking, and direct integration with Kubernetes-native tools. This mode is now the preferred choice for most production scenarios, and is especially recommended for serving Large Language Models (LLMs) due to its flexibility and advanced features.
 
-- **Serverless Mode**: Leverages Knative for automatic scaling, including scale-to-zero. This mode is well-suited for dynamic workloads and environments where resource efficiency is critical, but may introduce additional complexity and dependencies.
+- **Knative Mode**: Leverages Knative for automatic scaling, including scale-to-zero. This mode is well-suited for dynamic workloads and environments where resource efficiency is critical, but may introduce additional complexity and dependencies.
 
 ## In This Section
 

--- a/docs/developer-guide/index.md
+++ b/docs/developer-guide/index.md
@@ -148,11 +148,11 @@ For local development, we recommend using either:
 
 KServe offers two deployment modes:
 
-- **Serverless deployment** requires `Knative Serving` for request-based auto-scaling, scale-to-zero, and canary rollouts
+- **Knative deployment** requires `Knative Serving` for request-based auto-scaling, scale-to-zero, and canary rollouts
 - **Raw deployment** doesn't require Knative, suitable for generative inference workloads with stable resource allocation
 
 For networking:
-- **Serverless mode**: Requires Knative Serving; while Istio is recommended as the networking layer for Knative, you can use any ingress/networking solution supported by Knative (like Kourier or Contour)
+- **Knative mode**: Requires Knative Serving; while Istio is recommended as the networking layer for Knative, you can use any ingress/networking solution supported by Knative (like Kourier or Contour)
 - **Raw deployment**: Uses Gateway API or standard Kubernetes Ingress, compatible with various networking implementations
 
 Note that the quick install script installs Istio by default for both deployment modes for convenience.
@@ -435,7 +435,7 @@ Error: Internal error occurred: failed calling webhook "isvc.serving.kserve.io"
 - For raw mode, check Gateway resources: `kubectl get gateways,httproutes -A`
 - Verify network policies allow traffic to your services
 
-#### Slow Cold Start in Serverless Mode
+#### Slow Cold Start in Knative Mode
 - Consider setting `minScale` in your InferenceService spec to keep a minimum number of pods ready
 - Check for large container images that might be slow to pull
 - Review resource limits and requests

--- a/docs/getting-started/genai-first-isvc.md
+++ b/docs/getting-started/genai-first-isvc.md
@@ -17,7 +17,7 @@ Since your LLM is deployed as an InferenceService rather than a basic Kubernetes
 Before you begin, ensure you have followed the [KServe Quickstart Guide](quickstart-guide.md) to set up KServe in your Kubernetes cluster. This guide assumes you have a working KServe installation and a Kubernetes cluster ready for deployment.
 
 :::tip
-KServe recommends Raw Deployment for Generative AI use cases.
+KServe recommends Standard Deployment for Generative AI use cases.
 :::
 
 ### 1. Create a namespace

--- a/docs/getting-started/predictive-first-isvc.md
+++ b/docs/getting-started/predictive-first-isvc.md
@@ -95,7 +95,7 @@ sklearn-iris   http://sklearn-iris.kserve-test.example.com         True         
 ```
 :::
 
-:::tip[Serverless Custom Domain]
+:::tip[Knative serverless Custom Domain]
 If your DNS contains example.com please consult your admin for configuring DNS or using [custom domain](https://knative.dev/docs/serving/using-a-custom-domain).
 :::
 

--- a/docs/getting-started/quickstart-guide.md
+++ b/docs/getting-started/quickstart-guide.md
@@ -107,7 +107,7 @@ KServe Quickstart Environments are for experimentation use only. For production 
 ```
 
 </TabItem>
-<TabItem value="serverless" label="Serverless">
+<TabItem value="knative" label="Knative">
 
 ```bash
    curl -s "https://raw.githubusercontent.com/kserve/kserve/release-{{kserveDocsVersion}}/hack/quick_install.sh" | bash

--- a/docs/getting-started/quickstart-guide.md
+++ b/docs/getting-started/quickstart-guide.md
@@ -100,7 +100,7 @@ KServe Quickstart Environments are for experimentation use only. For production 
 :::
 
 <Tabs groupId="deployment-type">
-<TabItem value="raw" label="Raw Deployment" default>
+<TabItem value="raw" label="Standard Deployment" default>
 
 ```bash
    curl -s "https://raw.githubusercontent.com/kserve/kserve/release-{{kserveDocsVersion}}/hack/quick_install.sh" | bash -r

--- a/docs/model-serving/generative-inference/autoscaling/autoscaling.md
+++ b/docs/model-serving/generative-inference/autoscaling/autoscaling.md
@@ -8,7 +8,7 @@ description: Learn how to autoscale InferenceService in Kubernetes using KEDA wi
 [KEDA (Kubernetes Event-driven Autoscaler)](https://keda.sh) is a lightweight, open-source component that extends Kubernetes' scaling capabilities by enabling event-driven scaling for any container workload, allowing applications to scale based on external metrics such as [vLLM metrics](https://docs.vllm.ai/en/latest/serving/metrics.html) for the number of waiting requests or KV Cache usage.
 
 :::note
-Autoscaling using KEDA is only available in RawDeployment mode.
+Autoscaling using KEDA is only available in Standard mode.
 :::
 
 ## Scale using the Metrics
@@ -85,7 +85,7 @@ kind: InferenceService
 metadata:
   name: huggingface-qwen
   annotations:
-    serving.kserve.io/deploymentMode: "RawDeployment"
+    serving.kserve.io/deploymentMode: "Standard"
     serving.kserve.io/autoscalerClass: "keda"
     serving.kserve.io/enable-prometheus-scraping: "true"
     prometheus.io/scrape: "true"
@@ -237,7 +237,7 @@ kind: InferenceService
 metadata:
   name: huggingface-qwen
   annotations:
-    serving.kserve.io/deploymentMode: "RawDeployment"
+    serving.kserve.io/deploymentMode: "Standard"
     serving.kserve.io/autoscalerClass: "keda"
     sidecar.opentelemetry.io/inject: "huggingface-qwen-predictor"
 spec:

--- a/docs/model-serving/generative-inference/multi-node/multi-node.md
+++ b/docs/model-serving/generative-inference/multi-node/multi-node.md
@@ -14,7 +14,7 @@ This guide provides step-by-step instructions on setting up multi-node and multi
 
 ## Restrictions
 
-- Multi-node functionality is only supported in **RawDeployment** mode.
+- Multi-node functionality is only supported in **Standard** mode.
 - **Auto-scaling is not available** for multi-node setups. 
 - A **Persistent Volume Claim (PVC)** is required for multi-node configurations, and it must support the **ReadWriteMany (RWX)** access mode.
 
@@ -134,7 +134,7 @@ kind: InferenceService
 metadata:
   name: huggingface-llama3
   annotations:
-    serving.kserve.io/deploymentMode: RawDeployment
+    serving.kserve.io/deploymentMode: Standard
     serving.kserve.io/autoscalerClass: none
 spec:
   predictor:
@@ -289,7 +289,7 @@ apiVersion: serving.kserve.io/v1beta1
 kind: InferenceService
 metadata:
   annotations:
-    serving.kserve.io/deploymentMode: RawDeployment
+    serving.kserve.io/deploymentMode: Standard
     serving.kserve.io/autoscalerClass: none
   name: huggingface-llama3
 spec:

--- a/docs/model-serving/node-scheduling/isvc-node-scheduling.md
+++ b/docs/model-serving/node-scheduling/isvc-node-scheduling.md
@@ -7,9 +7,9 @@ description: Learn how to schedule InferenceService components on specific nodes
 
 KServe allows you to schedule `InferenceService` components on specific nodes in your Kubernetes cluster using standard Kubernetes scheduling features like node selectors, node affinity, and tolerations. These features are available in both deployment modes:
 
-- **Serverless Deployment**: The default mode powered by Knative, which provides scale-to-zero capabilities but requires specific Knative configurations to enable node scheduling features.
+- **Knative Deployment**: The default mode powered by Knative, which provides scale-to-zero capabilities but requires specific Knative configurations to enable node scheduling features.
   
-- **Raw Deployment**: A mode that creates standard Kubernetes resources (Deployments, Services) without Knative, which supports node scheduling by default but doesn't provide scale-to-zero capabilities.
+- **Standard Deployment**: A mode that creates standard Kubernetes resources (Deployments, Services) without Knative, which supports node scheduling by default but doesn't provide scale-to-zero capabilities.
 
 ## Setup
 
@@ -19,7 +19,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 <Tabs>
-<TabItem value="serverless" label="Serverless Deployment" default>
+<TabItem value="serverless" label="Knative Deployment" default>
 
 For serverless deployment mode, you must enable the Knative flags to support node scheduling features (see [Install Knative Serving Note](../../admin-guide/serverless/serverless.md#1-install-knative-serving)).
 
@@ -73,7 +73,7 @@ kubectl edit configmap config-features -n knative-serving
 Simply add the flags in the `data` section.
 
 </TabItem>
-<TabItem value="raw" label="Raw Deployment">
+<TabItem value="raw" label="Standard Deployment">
 
 For raw deployment mode, no special configuration is required to enable node scheduling features. Node selector, node affinity, and tolerations are supported out-of-the-box in standard Kubernetes deployments.
 
@@ -82,7 +82,7 @@ To use raw deployment mode with your `InferenceService`, simply add the followin
 ```yaml
 metadata:
   annotations:
-    serving.kserve.io/deploymentMode: RawDeployment
+    serving.kserve.io/deploymentMode: Standard
 ```
 
 </TabItem>
@@ -149,7 +149,7 @@ In this example, our `predictor` will only run on the node with the label `k8s.a
 You can learn more about recommended label names for GPU nodes when using kubernetes autoscaler by checking your cloud provider's documentation.
 
 <Tabs>
-<TabItem value="serverless" label="Serverless Deployment" default>
+<TabItem value="serverless" label="Knative Deployment" default>
 
 ```yaml
 apiVersion: "serving.kserve.io/v1beta1"
@@ -174,7 +174,7 @@ spec:
 ```
 
 </TabItem>
-<TabItem value="raw" label="Raw Deployment">
+<TabItem value="raw" label="Standard Deployment">
 
 ```yaml
 apiVersion: "serving.kserve.io/v1beta1"
@@ -182,7 +182,7 @@ kind: "InferenceService"
 metadata:
   name: "torchscript-cifar"
   annotations:
-    serving.kserve.io/deploymentMode: RawDeployment
+    serving.kserve.io/deploymentMode: Standard
 spec:
   predictor:
     nodeSelector:

--- a/docs/model-serving/predictive-inference/autoscaling/hpa-autoscaler.md
+++ b/docs/model-serving/predictive-inference/autoscaling/hpa-autoscaler.md
@@ -5,14 +5,14 @@ description: "Learn how to autoscale InferenceServices with Kubernetes Horizonta
 
 # Autoscaling with Kubernetes HPA
 
-KServe supports `RawDeployment` mode to enable `InferenceService` deployment with the following Kubernetes resources:
+KServe supports `Standard` mode to enable `InferenceService` deployment with the following Kubernetes resources:
 
 - [`Deployment`](https://kubernetes.io/docs/concepts/workloads/controllers/deployment)
 - [`Service`](https://kubernetes.io/docs/concepts/services-networking/service)
 - [`Ingress`](https://kubernetes.io/docs/concepts/services-networking/ingress)
 - [`Horizontal Pod Autoscaler`](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale)
 
-Compared to Serverless deployment, Raw deployment mode unlocks Knative limitations such as mounting multiple volumes. However, "Scale down to zero" is not supported in `RawDeployment` mode.
+Compared to Knative deployment, Raw deployment mode unlocks Knative limitations such as mounting multiple volumes. However, "Scale down to zero" is not supported in `Standard` mode.
 
 ## Prerequisites
 
@@ -23,9 +23,9 @@ Before you begin, make sure you have:
 - [Metrics Server](https://github.com/kubernetes-sigs/metrics-server) installed on your Kubernetes cluster for HPA to function properly.
 - Basic understanding of Kubernetes [Horizontal Pod Autoscaler](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) concepts.
 
-## HPA in Raw Deployment
+## HPA in Standard Deployment
 
-When using KServe with the `RawDeployment` mode, Knative is not required. In this mode, if you deploy an `InferenceService`, KServe uses **Kubernetes' Horizontal Pod Autoscaler (HPA)** for autoscaling instead of **Knative Pod Autoscaler (KPA)**. For information on using Knative Autoscaler in KServe, you can refer to the [Knative Autoscaler](./kpa-autoscaler.md) documentation.
+When using KServe with the `Standard` mode, Knative is not required. In this mode, if you deploy an `InferenceService`, KServe uses **Kubernetes' Horizontal Pod Autoscaler (HPA)** for autoscaling instead of **Knative Pod Autoscaler (KPA)**. For information on using Knative Autoscaler in KServe, you can refer to the [Knative Autoscaler](./kpa-autoscaler.md) documentation.
 
 Here's an example of creating an InferenceService that uses HPA:
 
@@ -35,7 +35,7 @@ kind: "InferenceService"
 metadata:
   name: "sklearn-iris-hpa"
   annotations:
-    serving.kserve.io/deploymentMode: RawDeployment
+    serving.kserve.io/deploymentMode: Standard
     serving.kserve.io/autoscalerClass: hpa
 spec:
   predictor:
@@ -67,7 +67,7 @@ kubectl apply -f sklearn-iris-hpa.yaml
 
 Concurrency and RPS metrics are only supported via Knative Pod Autoscaler. You can refer to [Knative Autoscaler Metrics](./kpa-autoscaler.md) documentation for more information on those metrics.
 
-## Disable HPA in Raw Deployment
+## Disable HPA in Standard Deployment
 
 If you want to use external autoscaler tools or manage scaling manually, you can disable the Horizontal Pod Autoscaler (HPA) that KServe creates.
 

--- a/docs/model-serving/predictive-inference/autoscaling/keda-autoscaler.md
+++ b/docs/model-serving/predictive-inference/autoscaling/keda-autoscaler.md
@@ -32,7 +32,7 @@ kind: "InferenceService"
 metadata:
   name: "sklearn-v2-iris"
   annotations:
-    serving.kserve.io/deploymentMode: "RawDeployment"
+    serving.kserve.io/deploymentMode: "Standard"
     serving.kserve.io/autoscalerClass: "keda"
 spec:
   predictor:
@@ -158,7 +158,7 @@ kind: InferenceService
 metadata:
   name: huggingface-fbopt
   annotations:
-    serving.kserve.io/deploymentMode: "RawDeployment"
+    serving.kserve.io/deploymentMode: "Standard"
     serving.kserve.io/autoscalerClass: "keda"
     serving.kserve.io/enable-prometheus-scraping: "true"
     prometheus.io/scrape: "true"
@@ -335,7 +335,7 @@ kind: InferenceService
 metadata:
   name: huggingface-fbopt
   annotations:
-    serving.kserve.io/deploymentMode: "RawDeployment"
+    serving.kserve.io/deploymentMode: "Standard"
     serving.kserve.io/autoscalerClass: "keda"
     sidecar.opentelemetry.io/inject: "huggingface-fbopt-predictor"
 spec:

--- a/docs/model-serving/predictive-inference/autoscaling/kpa-autoscaler.md
+++ b/docs/model-serving/predictive-inference/autoscaling/kpa-autoscaler.md
@@ -9,7 +9,7 @@ KServe leverages Knative Pod Autoscaler (KPA) to automatically scale your infere
 
 :::note
 
-The Knative Pod Autoscaler is only supported in Serverless deployment mode.
+The Knative Pod Autoscaler is only supported in Knative deployment mode.
 
 :::
 

--- a/docs/model-serving/predictive-inference/detect/alibi/alibi-detect.md
+++ b/docs/model-serving/predictive-inference/detect/alibi/alibi-detect.md
@@ -13,7 +13,7 @@ components:
 - Outlier detector flags single instances which do not follow the training distribution.
 
 The architecture used is shown below and links the payload logging available within KServe with asynchronous processing of those payloads in
-KNative to detect outliers.
+Knative to detect outliers.
 
 ![Architecture](./architecture.png)
 
@@ -26,7 +26,7 @@ KNative to detect outliers.
 A [CIFAR10](https://www.cs.toronto.edu/~kriz/cifar.html) Outlier Detector. Run the [notebook demo](https://github.com/kserve/kserve/blob/master/docs/samples/outlier-detection/alibi-detect/cifar10/cifar10_outlier.ipynb) to test.
 
 :::tip
-The notebook requires KNative Eventing >= 0.18.
+The notebook requires Knative Eventing >= 0.18.
 :::
 
 ## CIFAR10 Drift Detector
@@ -34,5 +34,5 @@ The notebook requires KNative Eventing >= 0.18.
 A [CIFAR10](https://www.cs.toronto.edu/~kriz/cifar.html) Drift Detector. Run the [notebook demo](https://github.com/kserve/kserve/blob/master/docs/samples/drift-detection/alibi-detect/cifar10/cifar10_drift.ipynb) to test.
 
 :::tip
-The notebook requires KNative Eventing >= 0.18.
+The notebook requires Knative Eventing >= 0.18.
 :::

--- a/docs/model-serving/predictive-inference/frameworks/lightgbm/lightgbm.md
+++ b/docs/model-serving/predictive-inference/frameworks/lightgbm/lightgbm.md
@@ -277,7 +277,7 @@ KServe currently supports exposing either HTTP or gRPC port, not both simultaneo
 :::
 
 <Tabs groupId="deployment-type">
-<TabItem value="serverless" label="Serverless" default>
+<TabItem value="serverless" label="Knative" default>
 
 ```yaml
 apiVersion: "serving.kserve.io/v1beta1"
@@ -299,7 +299,7 @@ spec:
 ```
 
 </TabItem>
-<TabItem value="raw" label="Raw Deployment">
+<TabItem value="raw" label="Standard Deployment">
 
 ```yaml
 apiVersion: "serving.kserve.io/v1beta1"

--- a/docs/model-serving/predictive-inference/frameworks/paddle/paddle.md
+++ b/docs/model-serving/predictive-inference/frameworks/paddle/paddle.md
@@ -293,7 +293,7 @@ KServe currently supports exposing either HTTP or gRPC port, not both simultaneo
 :::
 
 <Tabs groupId="deployment-type">
-<TabItem value="serverless" label="Serverless" default>
+<TabItem value="serverless" label="Knative" default>
 
 ```yaml
 apiVersion: "serving.kserve.io/v1beta1"
@@ -315,7 +315,7 @@ spec:
 ```
 
 </TabItem>
-<TabItem value="raw" label="Raw Deployment">
+<TabItem value="raw" label="Standard Deployment">
 
 ```yaml
 apiVersion: "serving.kserve.io/v1beta1"

--- a/docs/model-serving/predictive-inference/frameworks/pmml/pmml.md
+++ b/docs/model-serving/predictive-inference/frameworks/pmml/pmml.md
@@ -283,7 +283,7 @@ KServe currently supports exposing either HTTP or gRPC port, not both simultaneo
 :::
 
 <Tabs groupId="deployment-type">
-<TabItem value="serverless" label="Serverless" default>
+<TabItem value="serverless" label="Knative" default>
 
 ```yaml
 apiVersion: "serving.kserve.io/v1beta1"

--- a/docs/model-serving/predictive-inference/frameworks/sklearn/sklearn.md
+++ b/docs/model-serving/predictive-inference/frameworks/sklearn/sklearn.md
@@ -176,7 +176,7 @@ KServe currently supports exposing either HTTP or gRPC port, not both simultaneo
 :::
 
 <Tabs groupId="deployment-type">
-<TabItem value="serverless" label="Serverless" default>
+<TabItem value="serverless" label="Knative" default>
 
 ```yaml
 apiVersion: "serving.kserve.io/v1beta1"
@@ -198,7 +198,7 @@ spec:
 ```
 
 </TabItem>
-<TabItem value="raw" label="Raw Deployment">
+<TabItem value="raw" label="Standard Deployment">
 
 ```yaml
 apiVersion: "serving.kserve.io/v1beta1"

--- a/docs/model-serving/predictive-inference/frameworks/spark-mllib/spark-mllib.md
+++ b/docs/model-serving/predictive-inference/frameworks/spark-mllib/spark-mllib.md
@@ -291,7 +291,7 @@ KServe currently supports exposing either HTTP or gRPC port, not both simultaneo
 :::
 
 <Tabs groupId="deployment-type">
-<TabItem value="serverless" label="Serverless" default>
+<TabItem value="serverless" label="Knative" default>
 
 ```yaml
 apiVersion: "serving.kserve.io/v1beta1"
@@ -313,7 +313,7 @@ spec:
 ```
 
 </TabItem>
-<TabItem value="raw" label="Raw Deployment">
+<TabItem value="raw" label="Standard Deployment">
 
 ```yaml
 apiVersion: "serving.kserve.io/v1beta1"

--- a/docs/model-serving/predictive-inference/frameworks/tensorflow/tensorflow.md
+++ b/docs/model-serving/predictive-inference/frameworks/tensorflow/tensorflow.md
@@ -120,7 +120,7 @@ curl -v -H "Host: ${SERVICE_HOSTNAME}" -H "Content-Type: application/json" http:
 KServe also supports gRPC for inference requests. To create an `InferenceService` that exposes a gRPC endpoint:
 
 <Tabs groupId="deployment-type">
-<TabItem value="serverless" label="Serverless" default>
+<TabItem value="serverless" label="Knative" default>
 
 ```yaml
 apiVersion: "serving.kserve.io/v1beta1"
@@ -147,7 +147,7 @@ spec:
 ```
 
 </TabItem>
-<TabItem value="raw" label="Raw Deployment" default>
+<TabItem value="raw" label="Standard Deployment" default>
 
 ```yaml
 apiVersion: "serving.kserve.io/v1beta1"

--- a/docs/model-serving/predictive-inference/frameworks/triton/tensorflow/tensorflow.md
+++ b/docs/model-serving/predictive-inference/frameworks/triton/tensorflow/tensorflow.md
@@ -28,7 +28,7 @@ Before you begin, make sure you have:
 - Basic knowledge of TensorFlow, BERT models, and Triton Inference Server.
 - kubectl CLI tool configured with your cluster.
 
-## Setup (Serverless Mode Only)
+## Setup (Knative Mode Only)
 
 1. Skip [tag resolution](https://knative.dev/docs/serving/tag-resolution/) for `nvcr.io` which requires authentication to resolve Triton inference server image digest:
 

--- a/docs/model-serving/predictive-inference/frameworks/triton/torchscript/torchscript.md
+++ b/docs/model-serving/predictive-inference/frameworks/triton/torchscript/torchscript.md
@@ -20,7 +20,7 @@ Before you begin, make sure you have:
 - Basic knowledge of PyTorch, TorchScript, and Triton Inference Server.
 - kubectl CLI tool configured with your cluster.
 
-## Setup (Serverless Mode Only)
+## Setup (Knative Mode Only)
 
 1. Skip [tag resolution](https://knative.dev/docs/serving/tag-resolution/) for `nvcr.io` which requires auth to resolve Triton inference server image digest:
 
@@ -247,7 +247,7 @@ Error Set:
 
 Create the inference service YAML and expose the gRPC port. Currently, only one port is allowed to expose either HTTP or gRPC port, and by default, the HTTP port is exposed:
 <Tabs groupId="deployment-type">
-<TabItem value="serverless" label="Serverless" default>
+<TabItem value="serverless" label="Knative" default>
 
 ```yaml
 apiVersion: serving.kserve.io/v1beta1
@@ -277,7 +277,7 @@ spec:
           memory: 2Gi
 ```
 </TabItem>
-<TabItem value="raw" label="Raw Deployment">
+<TabItem value="raw" label="Standard Deployment">
 
 ```yaml
 apiVersion: serving.kserve.io/v1beta1

--- a/docs/model-serving/predictive-inference/frameworks/xgboost/xgboost.md
+++ b/docs/model-serving/predictive-inference/frameworks/xgboost/xgboost.md
@@ -188,7 +188,7 @@ KServe currently supports exposing either HTTP or gRPC port, not both simultaneo
 :::
 
 <Tabs groupId="deployment-type">
-<TabItem value="serverless" label="Serverless" default>
+<TabItem value="serverless" label="Knative" default>
 
 ```yaml
 apiVersion: "serving.kserve.io/v1beta1"
@@ -210,7 +210,7 @@ spec:
 ```
 
 </TabItem>
-<TabItem value="raw" label="Raw Deployment">
+<TabItem value="raw" label="Standard Deployment">
 
 ```yaml
 apiVersion: "serving.kserve.io/v1beta1"

--- a/docs/model-serving/predictive-inference/logger/basic-logger.md
+++ b/docs/model-serving/predictive-inference/logger/basic-logger.md
@@ -23,7 +23,7 @@ Before setting up inference logging, make sure you have:
 First, you need to set up a message dumper service that will receive and log the inference events.
 
 <Tabs groupId="deployment-type">
-  <TabItem value="raw" label="Raw Deployment" default>
+  <TabItem value="raw" label="Standard Deployment" default>
 
 Create a standard Kubernetes deployment and service as the message dumper:
 
@@ -61,7 +61,7 @@ spec:
 ```
 
   </TabItem>
-  <TabItem value="serverless" label="Serverless Deployment (Knative)">
+  <TabItem value="serverless" label="Knative Deployment (Knative)">
 
 Create a Knative Service as the message dumper:
 
@@ -165,7 +165,7 @@ kubectl logs $(kubectl get pod -l app=message-dumper -o jsonpath='{.items[0].met
 ```
 
   </TabItem>
-  <TabItem value="serverless" label="Serverless Deployment (Knative)">
+  <TabItem value="serverless" label="Knative Deployment (Knative)">
 
 ```bash
 kubectl logs $(kubectl get pod -l serving.knative.dev/service=message-dumper -o jsonpath='{.items[0].metadata.name}') user-container
@@ -250,7 +250,7 @@ kubectl delete svc message-dumper
 ```
 
   </TabItem>
-  <TabItem value="serverless" label="Serverless Deployment (Knative)">
+  <TabItem value="serverless" label="Knative Deployment (Knative)">
 
 ```bash
 kubectl delete isvc sklearn-iris

--- a/docs/model-serving/predictive-inference/transformers/collocation/collocation.md
+++ b/docs/model-serving/predictive-inference/transformers/collocation/collocation.md
@@ -158,7 +158,7 @@ model container.
 
 :::note
 
-In Serverless mode, specifying ports for predictor will result in isvc creation failure as specifying multiple ports
+In Knative mode, specifying ports for predictor will result in isvc creation failure as specifying multiple ports
 is not supported by knative. Due to this limitation predictor cannot be exposed outside of the cluster.
 For more info see, [knative discussion on multiple ports](https://github.com/knative/serving/issues/8471).
 
@@ -323,7 +323,7 @@ spec:
 
 :::note
 
-Do not specify ports for predictor in the serving runtime for Serverless deployment. This is not supported by knative. 
+Do not specify ports for predictor in the serving runtime for Knative deployment. This is not supported by knative. 
 For more information, please take a look at [knative discussion on multiple ports](https://github.com/knative/serving/issues/8471).
 
 :::

--- a/docs/model-serving/storage/certificate/self-signed.md
+++ b/docs/model-serving/storage/certificate/self-signed.md
@@ -17,7 +17,7 @@ This document explains three methods that can be used in KServe, described below
   
 :::note
 
-This is only available for `RawDeployment` and `Serverless`. For ModelMesh, you should add CA bundle content into the [`certificate` parameter in `storage-config`](https://github.com/kserve/modelmesh-serving/blob/main/docs/predictors/setup-storage.md).
+This is only available for `Standard` and `Knative`. For ModelMesh, you should add CA bundle content into the [`certificate` parameter in `storage-config`](https://github.com/kserve/modelmesh-serving/blob/main/docs/predictors/setup-storage.md).
 
 :::
 

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -299,7 +299,7 @@ const sidebars: SidebarsConfig = {
             'admin-guide/modelmesh',
             {
               type: 'category',
-              label: 'Serverless Deployment',
+              label: 'Knative Deployment',
               items: [
                 'admin-guide/serverless/serverless',
                 'admin-guide/serverless/kourier-networking/index',


### PR DESCRIPTION
Updates doc for https://github.com/kserve/kserve/pull/4608

Fixes #4609