### PR TITLE
docs: correct bash argument passing syntax in quickstart documentation

### DIFF
--- a/docs/getting-started/quickstart-guide.md
+++ b/docs/getting-started/quickstart-guide.md
@@ -103,7 +103,7 @@ KServe Quickstart Environments are for experimentation use only. For production 
 <TabItem value="raw" label="Standard Deployment" default>
 
 ```bash
-   curl -s "https://raw.githubusercontent.com/kserve/kserve/release-{{kserveDocsVersion}}/hack/quick_install.sh" | bash -r
+   curl -s "https://raw.githubusercontent.com/kserve/kserve/release-{{kserveDocsVersion}}/hack/quick_install.sh" | bash -s -- -r
 ```
 
 </TabItem>


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`kserve/website` GitHub repository](https://github.com/kserve/website).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/help/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/help/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the KServe blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, add the corresponding "cherrypick-0.X"
label to the original PR; for example, "cherrypick-0.12".
Best practice is to open a PR for the cherry-pick yourself after your original PR has been merged
into the main branch.
After the cherry-pick PR has merged, remove the cherry-pick label from the original PR.

For all resources for contributing to the KServe documentation, see the
[KServe contributor's guide](/docs/help/contributor/mkdocs-contributor-guide.md).

 -->

### Problem
The current quickstart guide instructs users to install KServe in RawDeployment mode using:
```bash
curl -s "https://raw.githubusercontent.com/kserve/kserve/release-0.15/hack/quick_install.sh" | bash -r
```

This command fails with the error:
```
bash: line 57: /dev/null: restricted: cannot redirect output
😱 Helm command not found. Please install Helm.
```

The issue occurs because `-r` is interpreted by bash as the restricted mode flag, rather than being passed as an argument to the script. This prevents the script from executing properly and confuses users attempting to install KServe in standard (RawDeployment) mode.

### Root Cause
When piping a script to bash, any flags after `bash` are interpreted by bash itself, not passed to the script. The `-r` flag enables bash's restricted mode, which prevents output redirection and causes the script to fail at the first redirect operation.

### Solution
Update the documentation to use the correct syntax for passing arguments to piped scripts:
```bash
curl -s "https://raw.githubusercontent.com/kserve/kserve/release-0.15/hack/quick_install.sh" | bash -s -- -r
```

The `-s` flag tells bash to read from stdin, and `--` indicates that everything following should be passed as arguments to the script.


### Impact
This fix will prevent installation failures for users following the quickstart guide and improve the overall onboarding experience for KServe.
