### PR TITLE
fix: multiple storage uri examples using `path` instead of `mountPath`

### DIFF
--- a/docs/model-serving/storage/multiple-storage-uris.md
+++ b/docs/model-serving/storage/multiple-storage-uris.md
@@ -177,8 +177,8 @@ predictor:
 # OR storageUris
 predictor:
   model:
-    storageUris:
-      - uri: s3://bucket/model
+  storageUris:
+    - uri: s3://bucket/model
 ```
 
 </TabItem>
@@ -189,8 +189,8 @@ predictor:
 predictor:
   model:
     storageUri: s3://bucket/model
-    storageUris:
-      - uri: s3://bucket/other-model
+  storageUris:
+    - uri: s3://bucket/other-model
 ```
 
 </TabItem>

--- a/versioned_docs/version-0.16/model-serving/storage/multiple-storage-uris.md
+++ b/versioned_docs/version-0.16/model-serving/storage/multiple-storage-uris.md
@@ -177,8 +177,8 @@ predictor:
 # OR storageUris
 predictor:
   model:
-    storageUris:
-      - uri: s3://bucket/model
+  storageUris:
+    - uri: s3://bucket/model
 ```
 
 </TabItem>
@@ -189,8 +189,8 @@ predictor:
 predictor:
   model:
     storageUri: s3://bucket/model
-    storageUris:
-      - uri: s3://bucket/other-model
+  storageUris:
+    - uri: s3://bucket/other-model
 ```
 
 </TabItem>


### PR DESCRIPTION


Refer kserve/kserve#4819


