### PR TITLE
fix: update security contact email in contribution guide

### DIFF
--- a/docs/developer-guide/contribution.md
+++ b/docs/developer-guide/contribution.md
@@ -105,7 +105,7 @@ When you discover a security vulnerability in KServe, follow this secure reporti
 #### Step 2: Report Through Proper Channels
 Use one of these secure channels to report the vulnerability:
 - [GitHub Security Advisory](https://github.com/kserve/kserve/security/advisories/new) (preferred method)
-- Email the KServe security team at [kserve-security@lists.lfaidata.foundation](mailto:kserve-security@lists.lfaidata.foundation)
+- Email the KServe security team at [kserve-security@lists.cncf.io](mailto:kserve-security@lists.cncf.io)
 
 #### Step 3: Provide Detailed Information
 Include the following information in your report:

--- a/versioned_docs/version-0.16/developer-guide/contribution.md
+++ b/versioned_docs/version-0.16/developer-guide/contribution.md
@@ -105,7 +105,7 @@ When you discover a security vulnerability in KServe, follow this secure reporti
 #### Step 2: Report Through Proper Channels
 Use one of these secure channels to report the vulnerability:
 - [GitHub Security Advisory](https://github.com/kserve/kserve/security/advisories/new) (preferred method)
-- Email the KServe security team at [kserve-security@lists.lfaidata.foundation](mailto:kserve-security@lists.lfaidata.foundation)
+- Email the KServe security team at [kserve-security@lists.cncf.io](mailto:kserve-security@lists.cncf.io)
 
 #### Step 3: Provide Detailed Information
 Include the following information in your report:


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`kserve/website` GitHub repository](https://github.com/kserve/website).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/help/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/help/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the KServe blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, add the corresponding "cherrypick-0.X"
label to the original PR; for example, "cherrypick-0.12".
Best practice is to open a PR for the cherry-pick yourself after your original PR has been merged
into the main branch.
After the cherry-pick PR has merged, remove the cherry-pick label from the original PR.

For all resources for contributing to the KServe documentation, see the
[KServe contributor's guide](/docs/help/contributor/mkdocs-contributor-guide.md).

 -->

