### PR TITLE
Update GIE and Gateway API version requirements for LLMIsvc

### DIFF
--- a/docs/admin-guide/kubernetes-deployment-llmisvc.md
+++ b/docs/admin-guide/kubernetes-deployment-llmisvc.md
@@ -25,8 +25,8 @@ LLMInferenceService is designed specifically for **Generative AI** workloads (LL
 
 - **Kubernetes**: Version 1.32+
 - **Cert Manager**: Version 1.18.0+
-- **Gateway API**: Version 1.2.1
-- **Gateway API Inference Extension (GIE)**: Version 0.3.0
+- **Gateway API**: Version 1.3.0+
+- **Gateway API Inference Extension (GIE)**: Version 1.2.0
 - **Gateway Provider**: Envoy Gateway v1.5.0+ 
 - **LeaderWorkerSet**: Version 0.6.2+ (for multi-node deployments)
 


### PR DESCRIPTION
Update minimum version requirements to match kserve/kserve#4886:
  - Gateway API Inference Extension (GIE): 0.3.0 → 1.2.0
  - Gateway API: 1.2.1 → 1.3.0+
