### PR TITLE
chore: replace flake8 by ruff check

### DIFF
--- a/docs/developer-guide/contribution.md
+++ b/docs/developer-guide/contribution.md
@@ -261,7 +261,7 @@ After submitting a PR:
 
 - Follow [PEP 8](https://www.python.org/dev/peps/pep-0008/) style guidelines
 - Use [Black](https://black.readthedocs.io/) for code formatting
-- Run `flake8` for linting
+- Run `ruff check` for linting
 - Include docstrings for all functions and classes
 
 ### Testing


### PR DESCRIPTION
Update the Python linting description to sync with this PR: https://github.com/kserve/kserve/pull/4981

## Proposed Changes

- Replace `flake8` tool for python linting by `ruff`

