### PR TITLE
Update presentations tag to community contributions

### DIFF
--- a/blog/tags.yml
+++ b/blog/tags.yml
@@ -8,7 +8,7 @@ announcements:
   permalink: /announcements
   description: Project Announcements
 
-presentations:
+community:
   label: Community
   permalink: /community
   description: Blog Contributed by Community Members


### PR DESCRIPTION
"Presentations" tag is not being used and sounds very specific. I am proposing changing this to "Community" instead.