### PR TITLE
Add Ran Pollak to blog authors

### DIFF
--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -88,7 +88,7 @@ yuzliu:
 
 RanPollak:
   name: Ran Pollak
-  title: KServe Contributor
+  title: KServe Community Member
   url: https://github.com/RanPollak
   image_url: https://github.com/RanPollak.png
   socials:


### PR DESCRIPTION
## Summary
- Added Ran Pollak to the blog authors list

## Test plan
- [ ] Verify the author entry follows the correct YAML format
- [ ] Confirm GitHub profile image URL is accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)