### PR TITLE
Small typo in OCI images docs

### DIFF
--- a/docs/model-serving/storage/providers/oci.md
+++ b/docs/model-serving/storage/providers/oci.md
@@ -166,7 +166,7 @@ Fine-tuning the behavior of Modelcars in KServe is possible through global confi
 To view the current configuration, use the following command:
 
 ```bash
-kubectl get cm -n kserve inferenceservice-config --jsonpath "{.data.storageInitializer}"
+kubectl get cm -n kserve inferenceservice-config -o jsonpath="{.data.storageInitializer}"
 ```
 
 :::tip[Sample Output]

--- a/versioned_docs/version-0.16/model-serving/storage/providers/oci.md
+++ b/versioned_docs/version-0.16/model-serving/storage/providers/oci.md
@@ -166,7 +166,7 @@ Fine-tuning the behavior of Modelcars in KServe is possible through global confi
 To view the current configuration, use the following command:
 
 ```bash
-kubectl get cm -n kserve inferenceservice-config --jsonpath "{.data.storageInitializer}"
+kubectl get cm -n kserve inferenceservice-config -o jsonpath="{.data.storageInitializer}"
 ```
 
 :::tip[Sample Output]


### PR DESCRIPTION
In the current version of the "Serving Models with OCI Images" page you provide a broken command to check the current `inferenceservice-config` value

<img width="1133" height="277" alt="image" src="https://github.com/user-attachments/assets/c265aeec-3100-413c-8405-20cbfb694efb" />

## Proposed Changes

- `--jsonpath` replaced with `-o jsonpath='...'` 