### PR TITLE
Adding an LLM Inference Service Tutorials page

### DIFF
--- a/docs/model-serving/generative-inference/llmisvc/llmisvc-envoy-ai-gateway.md
+++ b/docs/model-serving/generative-inference/llmisvc/llmisvc-envoy-ai-gateway.md
@@ -1,4 +1,6 @@
 ---
+sidebar_label: "Inference Gateway Extension"
+sidebar_position: 5
 title: LLMInferenceService with Inference Gateway Extension (IGW)
 description: How to integrate KServe LLMInferenceService with Envoy AI Gateway to manage LLM traffic and usage-based rate limits
 ---

--- a/docs/model-serving/generative-inference/llmisvc/tutorials.md
+++ b/docs/model-serving/generative-inference/llmisvc/tutorials.md
@@ -6,7 +6,21 @@ title: "LLMInferenceService Tutorials"
 
 # LLMInferenceService Tutorials
 
-There are a set of tutorial guides to deploying the KServe LLM Inference Service in a variety of configurations with a variety of models in the KServe repo.
+These are a set of tutorial guides for deploying the KServe LLM Inference Service in a variety of configurations with a variety of models. 
+
+All of the tutorials are present in the [KServe repo](https://github.com/kserve/kserve) under `samples/docs`.
+
+## End-to-end guide: Run GPT-OSS-20B with KServe and llm-d
+
+[E2E GPT OSS](https://github.com/kserve/kserve/tree/master/docs/samples/llmisvc/e2e-gpt-oss)
+
+This guide walks through deploying **RedHatAI/gpt-oss-20b** on Kubernetes using [KServe](https://kserve.github.io/website/). Steps are ordered from cluster setup through inference, AI gateway routing, optional prefix caching, and monitoring.
+
+There are 3 alternate deployments detailed here:
+
+1. default - a deployment of intelligent inference scheduling with vLLM and the llm-d scheduler
+1. precise prefix cache aware routing - an advanced configuration that takes advantage of vLLM KV-Events
+1. prefill-decode disaggregation - an advanced configuration that seperate vLLM pods for the prefill and the decode stages of inference.
 
 ## Single-Node GPU Deployment Examples
 
@@ -25,15 +39,3 @@ This contains example configurations for deploying the DeepSeek-R1-0528 model us
 [Precise Prefix KV Cache Routing](https://github.com/kserve/kserve/tree/master/docs/samples/llmisvc/precise-prefix-kv-cache-routing)
 
 This contains an example configuration demonstrating advanced KV cache routing with precise prefix matching to optimize inference performance by routing requests to instances with matching cached content.
-
-## End-to-end guide: Run GPT-OSS-20B with KServe and llm-d
-
-[E2E GPT OSS](https://github.com/kserve/kserve/tree/master/docs/samples/llmisvc/e2e-gpt-oss)
-
-This guide walks through deploying **RedHatAI/gpt-oss-20b** on Kubernetes using [KServe](https://kserve.github.io/website/). Steps are ordered from cluster setup through inference, AI gateway routing, optional prefix caching, and monitoring.
-
-There are 3 alternate deployments detailed here:
-
-1. default - a deployment of intelligent inference scheduling with vLLM and the llm-d scheduler
-1. precise prefix cache aware routing - an advanced configuration that takes advantage of vLLM KV-Events
-1. prefill-decode disaggregation - an advanced configuration that seperate vLLM pods for the prefill and the decode stages of inference.

--- a/docs/model-serving/generative-inference/llmisvc/tutorials.md
+++ b/docs/model-serving/generative-inference/llmisvc/tutorials.md
@@ -8,7 +8,7 @@ title: "LLMInferenceService Tutorials"
 
 These are a set of tutorial guides for deploying the KServe LLM Inference Service in a variety of configurations with a variety of models. 
 
-All of the tutorials are present in the [KServe repo](https://github.com/kserve/kserve) under `samples/docs`.
+All of the tutorials are present in the [KServe repo](https://github.com/kserve/kserve/tree/master/docs/samples/llmisvc) under `docs/samples/llmisvc`.
 
 ## End-to-end guide: Run GPT-OSS-20B with KServe and llm-d
 
@@ -20,7 +20,7 @@ There are 3 alternate deployments detailed here:
 
 1. default - a deployment of intelligent inference scheduling with vLLM and the llm-d scheduler
 1. precise prefix cache aware routing - an advanced configuration that takes advantage of vLLM KV-Events
-1. prefill-decode disaggregation - an advanced configuration that seperate vLLM pods for the prefill and the decode stages of inference.
+1. prefill-decode disaggregation - an advanced configuration that separates vLLM pods for the prefill and the decode stages of inference.
 
 ## Single-Node GPU Deployment Examples
 

--- a/docs/model-serving/generative-inference/llmisvc/tutorials.md
+++ b/docs/model-serving/generative-inference/llmisvc/tutorials.md
@@ -1,0 +1,39 @@
+---
+sidebar_label: "Tutorials"
+sidebar_position: 6
+title: "LLMInferenceService Tutorials"
+---
+
+# LLMInferenceService Tutorials
+
+There are a set of tutorial guides to deploying the KServe LLM Inference Service in a variety of configurations with a variety of models in the KServe repo.
+
+## Single-Node GPU Deployment Examples
+
+[Single Node GPU](https://github.com/kserve/kserve/tree/master/docs/samples/llmisvc/single-node-gpu)
+
+Contains example configurations for deploying LLM inference services on single-node GPU setups, ranging from basic load balancing to advanced prefill-decode separation with KV cache transfer.
+
+## DeepSeek-R1 Multi-Node Deployment Examples
+
+[DeepSeek R1 GPU RDMA RoCE](https://github.com/kserve/kserve/tree/master/docs/samples/llmisvc/dp-ep/deepseek-r1-gpu-rdma-roce)
+
+This contains example configurations for deploying the DeepSeek-R1-0528 model using data parallelism (DP) and expert parallelism (EP) across multiple nodes with GPU acceleration.
+
+## Precise Prefix KV Cache Routing
+
+[Precise Prefix KV Cache Routing](https://github.com/kserve/kserve/tree/master/docs/samples/llmisvc/precise-prefix-kv-cache-routing)
+
+This contains an example configuration demonstrating advanced KV cache routing with precise prefix matching to optimize inference performance by routing requests to instances with matching cached content.
+
+## End-to-end guide: Run GPT-OSS-20B with KServe and llm-d
+
+[E2E GPT OSS](https://github.com/kserve/kserve/tree/master/docs/samples/llmisvc/e2e-gpt-oss)
+
+This guide walks through deploying **RedHatAI/gpt-oss-20b** on Kubernetes using [KServe](https://kserve.github.io/website/). Steps are ordered from cluster setup through inference, AI gateway routing, optional prefix caching, and monitoring.
+
+There are 3 alternate deployments detailed here:
+
+1. default - a deployment of intelligent inference scheduling with vLLM and the llm-d scheduler
+1. precise prefix cache aware routing - an advanced configuration that takes advantage of vLLM KV-Events
+1. prefill-decode disaggregation - an advanced configuration that seperate vLLM pods for the prefill and the decode stages of inference.

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -114,6 +114,7 @@ const sidebars: SidebarsConfig = {
                 "model-serving/generative-inference/llmisvc/llmisvc-configuration",
                 "model-serving/generative-inference/llmisvc/llmisvc-dependencies",
                 "model-serving/generative-inference/llmisvc/llmisvc-envoy-ai-gateway",
+                "model-serving/generative-inference/llmisvc/tutorials",
               ],
             },
             {

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -158,6 +158,7 @@ const sidebars: SidebarsConfig = {
                 },
                 "model-serving/generative-inference/llmisvc/autoscaling/llmisvc-autoscaling",
                 "model-serving/generative-inference/llmisvc/autoscaling/llmisvc-autoscaling-examples",
+                "model-serving/generative-inference/llmisvc/tutorials",
               ],
             },
             {


### PR DESCRIPTION
Adding a new Tutorials page under Model Serving -> Generative Inference -> LLMInference to point to the docs/samples/llmisvc tutorials in the main website as suggested by @sivanantha321 

> Note: Now that [PR 5150 on kserve](https://github.com/kserve/kserve/pull/5150) has been merged, this can be reviewed.

## Proposed Changes

- Add a new [tutorials.md](docs/model-serving/generative-inference/llmisvc/tutorials.md) to the website
- Fix a header in [llmisvc-envoy-ai-gateway.md](docs/model-serving/generative-inference/llmisvc/llmisvc-envoy-ai-gateway.md)


