### PR TITLE
fix: pin kserve version in the examples

### DIFF
--- a/docs/model-serving/predictive-inference/frameworks/custom-predictor/grpc/requirements.txt
+++ b/docs/model-serving/predictive-inference/frameworks/custom-predictor/grpc/requirements.txt
@@ -1,3 +1,3 @@
-kserve
+kserve==0.17.0
 torchvision==0.18.0
-pillow >=10.3.0,<11.0.0
+pillow >=10.3.0

--- a/docs/model-serving/predictive-inference/frameworks/custom-predictor/ray/requirements.txt
+++ b/docs/model-serving/predictive-inference/frameworks/custom-predictor/ray/requirements.txt
@@ -1,3 +1,3 @@
-kserve[ray]
+kserve[ray]==0.17.0
 torchvision==0.18.0
-pillow >=10.3.0,<11.0.0
+pillow >=10.3.0

--- a/docs/model-serving/predictive-inference/frameworks/custom-predictor/rest/requirements.txt
+++ b/docs/model-serving/predictive-inference/frameworks/custom-predictor/rest/requirements.txt
@@ -1,3 +1,3 @@
-kserve
+kserve==0.17.0
 torchvision==0.18.0
-pillow >=10.3.0,<11.0.0
+pillow >=10.3.0

--- a/versioned_docs/version-0.16/model-serving/predictive-inference/frameworks/custom-predictor/grpc/requirements.txt
+++ b/versioned_docs/version-0.16/model-serving/predictive-inference/frameworks/custom-predictor/grpc/requirements.txt
@@ -1,5 +1,3 @@
-kserve
+kserve==0.16.0
 torchvision==0.18.0
-pillow >=10.3.0,<11.0.0
-numpy>=1.22.2 # not directly required, pinned by Snyk to avoid a vulnerability
-zipp>=3.19.1 # not directly required, pinned by Snyk to avoid a vulnerability
+pillow >=10.3.0

--- a/versioned_docs/version-0.16/model-serving/predictive-inference/frameworks/custom-predictor/ray/requirements.txt
+++ b/versioned_docs/version-0.16/model-serving/predictive-inference/frameworks/custom-predictor/ray/requirements.txt
@@ -1,3 +1,3 @@
-kserve[ray]
+kserve[ray]==0.16.0
 torchvision==0.18.0
-pillow >=10.3.0,<11.0.0
+pillow >=10.3.0

--- a/versioned_docs/version-0.16/model-serving/predictive-inference/frameworks/custom-predictor/rest/requirements.txt
+++ b/versioned_docs/version-0.16/model-serving/predictive-inference/frameworks/custom-predictor/rest/requirements.txt
@@ -1,4 +1,3 @@
-kserve
+kserve==0.16.0
 torchvision==0.18.0
-pillow >=10.3.0,<11.0.0
-zipp>=3.19.1 # not directly required, pinned by Snyk to avoid a vulnerability
+pillow >=10.3.0

--- a/versioned_docs/version-0.17/model-serving/predictive-inference/frameworks/custom-predictor/grpc/requirements.txt
+++ b/versioned_docs/version-0.17/model-serving/predictive-inference/frameworks/custom-predictor/grpc/requirements.txt
@@ -1,3 +1,3 @@
-kserve
+kserve==0.17.0
 torchvision==0.18.0
-pillow >=10.3.0,<11.0.0
+pillow >=10.3.0

--- a/versioned_docs/version-0.17/model-serving/predictive-inference/frameworks/custom-predictor/ray/requirements.txt
+++ b/versioned_docs/version-0.17/model-serving/predictive-inference/frameworks/custom-predictor/ray/requirements.txt
@@ -1,3 +1,3 @@
-kserve[ray]
+kserve[ray]==0.17.0
 torchvision==0.18.0
-pillow >=10.3.0,<11.0.0
+pillow >=10.3.0

--- a/versioned_docs/version-0.17/model-serving/predictive-inference/frameworks/custom-predictor/rest/requirements.txt
+++ b/versioned_docs/version-0.17/model-serving/predictive-inference/frameworks/custom-predictor/rest/requirements.txt
@@ -1,3 +1,3 @@
-kserve
+kserve==0.17.0
 torchvision==0.18.0
-pillow >=10.3.0,<11.0.0
+pillow >=10.3.0


### PR DESCRIPTION
chore:  By pinning KServe version to the given one, it will ensure that once users
        are trying the examples with buildpack it will install the versions defined
        by KServe and the installation process will pull latest version of the defined
        dependencies in the examples. Minimizing the Snyk alerts like: https://github.com/kserve/website/pull/597

        ```
        [Installing dependencies using pip]
        Creating virtual environment
        Running 'pip install -r requirements.txt'
        Collecting kserve==0.17.0 (from -r requirements.txt (line 1))

        ```

<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`kserve/website` GitHub repository](https://github.com/kserve/website).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/help/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/help/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the KServe blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, add the corresponding "cherrypick-0.X"
label to the original PR; for example, "cherrypick-0.12".
Best practice is to open a PR for the cherry-pick yourself after your original PR has been merged
into the main branch.
After the cherry-pick PR has merged, remove the cherry-pick label from the original PR.

For all resources for contributing to the KServe documentation, see the
[KServe contributor's guide](/docs/help/contributor/mkdocs-contributor-guide.md).

 -->

"Fixes #issue-number" or "Add description of the problem this PR solves"

## Proposed Changes <!-- Describe the changes the PR makes. -->

-
-
-

