### PR TITLE
docs: add ModelScope storage provider documentation

### DIFF
--- a/docs/model-serving/storage/overview.md
+++ b/docs/model-serving/storage/overview.md
@@ -28,6 +28,7 @@ KServe can serve models from various storage locations, including:
 - **[Git](./providers/git.md)** - Serve models from git repositories.
 - **[Persistent Volume Claims (PVC)](./providers/pvc.md)** - Use Kubernetes PVCs to store and serve models.
 - **[Hugging Face](./providers/hf.md)** - Directly serve models from the Hugging Face model hub.
+- **[ModelScope](./providers/ms.md)** - Directly serve models from the ModelScope model hub.
 - **[OCI Images](./providers/oci.md)** - Package and serve models as OCI container images using Modelcars.
 
 ## Storage Initializer

--- a/docs/model-serving/storage/providers/ms.md
+++ b/docs/model-serving/storage/providers/ms.md
@@ -101,7 +101,7 @@ spec:
         - name: MS_TOKEN  # Option 2 for authenticating with MS_TOKEN
           valueFrom:
             secretKeyRef:
-              name: ms-secret
+              name: storage-config
               key: MS_TOKEN
               optional: false
 ```

--- a/docs/model-serving/storage/providers/ms.md
+++ b/docs/model-serving/storage/providers/ms.md
@@ -1,0 +1,122 @@
+---
+title: ModelScope
+description: Deploy InferenceService with models from ModelScope Hub in KServe, including support for both public and private models.
+---
+
+# Deploy InferenceService with model from ModelScope Hub
+
+You can specify the `storageUri` field on `InferenceService` YAML with the following format to deploy the models from ModelScope Hub.
+
+```
+ms://${NAMESPACE}/${MODEL}:${REVISION}(optional)
+```
+
+e.g. `ms://qwen/Qwen2-0.5B-Instruct`
+
+[ModelScope](https://www.modelscope.cn) is one of the largest model hubs in China, hosting popular models such as Qwen, DeepSeek, and many others.
+
+## Public ModelScope Models
+
+If no credential is provided, anonymous client will be used to download the model from ModelScope repo.
+
+## Private ModelScope Models
+
+KServe supports authenticating with `MS_TOKEN` for downloading the model. Create a Kubernetes secret to store the ModelScope token.
+
+```yaml title="yaml"
+apiVersion: v1
+kind: Secret
+metadata:
+  name: storage-config
+type: Opaque
+data:
+  MS_TOKEN: bXN0X1ZOVXdSV0FHQmtJeFpmTEx1a3NlR3lvVVZvbnVOaUR1VU0==
+```
+
+## Deploy InferenceService with Models from ModelScope Hub
+
+### Option 1: Use Service Account with Secret Ref
+Create a Kubernetes `ServiceAccount` with the ModelScope token secret name reference and specify the `ServiceAccountName` in the `InferenceService` Spec.
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: msserviceacc
+secrets:
+  - name: storage-config
+---
+apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  name: modelscope-qwen
+spec:
+  predictor:
+    serviceAccountName: msserviceacc  # Option 1 for authenticating with MS_TOKEN
+    model:
+      modelFormat:
+        name: huggingface
+      args:
+        - --model_name=qwen
+        - --model_dir=/mnt/models
+      storageUri: ms://qwen/Qwen2-0.5B-Instruct
+      resources:
+        limits:
+          cpu: "6"
+          memory: 24Gi
+          nvidia.com/gpu: "1"
+        requests:
+          cpu: "6"
+          memory: 24Gi
+          nvidia.com/gpu: "1"
+```
+
+### Option 2: Use Environment Variable with Secret Ref
+Create a Kubernetes ModelScope token secret and specify the MS token secret reference using environment variable in the `InferenceService` Spec.
+
+```yaml
+apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  name: modelscope-qwen
+spec:
+  predictor:
+    model:
+      modelFormat:
+        name: huggingface
+      args:
+        - --model_name=qwen
+        - --model_dir=/mnt/models
+      storageUri: ms://qwen/Qwen2-0.5B-Instruct
+      resources:
+        limits:
+          cpu: "6"
+          memory: 24Gi
+          nvidia.com/gpu: "1"
+        requests:
+          cpu: "6"
+          memory: 24Gi
+          nvidia.com/gpu: "1"
+      env:
+        - name: MS_TOKEN  # Option 2 for authenticating with MS_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: ms-secret
+              key: MS_TOKEN
+              optional: false
+```
+
+## Check the InferenceService status.
+
+```bash
+kubectl get inferenceservices modelscope-qwen
+```
+
+:::tip[Expected Output]
+
+```bash
+NAME              URL                                                READY   PREV   LATEST   PREVROLLEDOUTREVISION   LATESTREADYREVISION                       AGE
+modelscope-qwen   http://modelscope-qwen.default.example.com         True           100                              modelscope-qwen-predictor-default-47q2g   7d23h
+```
+
+:::

--- a/docs/model-serving/storage/providers/ms.md
+++ b/docs/model-serving/storage/providers/ms.md
@@ -3,7 +3,7 @@ title: ModelScope
 description: Deploy InferenceService with models from ModelScope Hub in KServe, including support for both public and private models.
 ---
 
-# Deploy InferenceService with model from ModelScope Hub
+# Deploy InferenceService with models from ModelScope Hub
 
 You can specify the `storageUri` field on `InferenceService` YAML with the following format to deploy the models from ModelScope Hub.
 

--- a/docs/model-serving/storage/providers/ms.md
+++ b/docs/model-serving/storage/providers/ms.md
@@ -17,7 +17,7 @@ e.g. `ms://qwen/Qwen2-0.5B-Instruct`
 
 ## Public ModelScope Models
 
-If no credential is provided, anonymous client will be used to download the model from ModelScope repo.
+If no credential is provided, an anonymous client will be used to download the model from the ModelScope repository.
 
 ## Private ModelScope Models
 

--- a/docs/model-serving/storage/providers/ms.md
+++ b/docs/model-serving/storage/providers/ms.md
@@ -8,10 +8,12 @@ description: Deploy InferenceService with models from ModelScope Hub in KServe, 
 You can specify the `storageUri` field on `InferenceService` YAML with the following format to deploy the models from ModelScope Hub.
 
 ```
-ms://${NAMESPACE}/${MODEL}:${REVISION}(optional)
+modelscope://${OWNER}/${MODEL}[:${REVISION}]
 ```
 
-e.g. `ms://qwen/Qwen2-0.5B-Instruct`
+For example, `modelscope://Qwen/Qwen2.5-0.5B-Instruct`. To download a
+specific revision, append it after a colon, for example,
+`modelscope://Qwen/Qwen2.5-0.5B-Instruct:<revision>`.
 
 [ModelScope](https://www.modelscope.cn) is one of the largest model hubs in China, hosting popular models such as Qwen, DeepSeek, and many others.
 
@@ -21,7 +23,7 @@ If no credential is provided, an anonymous client will be used to download the m
 
 ## Private ModelScope Models
 
-KServe supports authenticating with `MS_TOKEN` for downloading the model. Create a Kubernetes secret to store the ModelScope token.
+KServe supports authenticating with `MODELSCOPE_API_TOKEN` for downloading the model. Create a Kubernetes secret to store the ModelScope token.
 
 ```yaml title="yaml"
 apiVersion: v1
@@ -30,7 +32,7 @@ metadata:
   name: storage-config
 type: Opaque
 data:
-  MS_TOKEN: bXN0X1ZOVXdSV0FHQmtJeFpmTEx1a3NlR3lvVVZvbnVOaUR1VU0==
+  MODELSCOPE_API_TOKEN: bXN0X1ZOVXdSV0FHQmtJeFpmTEx1a3NlR3lvVVZvbnVOaUR1VU0==
 ```
 
 ## Deploy InferenceService with Models from ModelScope Hub
@@ -52,14 +54,14 @@ metadata:
   name: modelscope-qwen
 spec:
   predictor:
-    serviceAccountName: msserviceacc  # Option 1 for authenticating with MS_TOKEN
+    serviceAccountName: msserviceacc  # Option 1 for authenticating with MODELSCOPE_API_TOKEN
     model:
       modelFormat:
         name: huggingface
       args:
         - --model_name=qwen
         - --model_dir=/mnt/models
-      storageUri: ms://qwen/Qwen2-0.5B-Instruct
+      storageUri: modelscope://Qwen/Qwen2.5-0.5B-Instruct
       resources:
         limits:
           cpu: "6"
@@ -87,7 +89,7 @@ spec:
       args:
         - --model_name=qwen
         - --model_dir=/mnt/models
-      storageUri: ms://qwen/Qwen2-0.5B-Instruct
+      storageUri: modelscope://Qwen/Qwen2.5-0.5B-Instruct
       resources:
         limits:
           cpu: "6"
@@ -98,11 +100,11 @@ spec:
           memory: 24Gi
           nvidia.com/gpu: "1"
       env:
-        - name: MS_TOKEN  # Option 2 for authenticating with MS_TOKEN
+        - name: MODELSCOPE_API_TOKEN  # Option 2 for authenticating with MODELSCOPE_API_TOKEN
           valueFrom:
             secretKeyRef:
               name: storage-config
-              key: MS_TOKEN
+              key: MODELSCOPE_API_TOKEN
               optional: false
 ```
 

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -298,6 +298,7 @@ const sidebars: SidebarsConfig = {
               label: 'Supported Providers',
               items: [
                 'model-serving/storage/providers/hf',
+                'model-serving/storage/providers/ms',
                 'model-serving/storage/providers/azure',
                 'model-serving/storage/providers/s3/s3',
                 'model-serving/storage/providers/gcs',


### PR DESCRIPTION
  docs: add ModelScope storage provider documentation

  This PR adds documentation for the ModelScope storage provider
  feature introduced in kserve/kserve#5330.

  ModelScope (https://www.modelscope.cn) is one of the largest model
  hubs in China, hosting popular models such as Qwen, DeepSeek, and
  many others. Users can now use `ms://` URIs in their
  InferenceServices to download models directly from ModelScope.

  ## Proposed Changes

  - Add `docs/model-serving/storage/providers/ms.md` with complete
  ModelScope storage documentation
  - Update `docs/model-serving/storage/overview.md` to include
  ModelScope in the storage providers list
  - Update `sidebars.ts` to add ModelScope to the navigation menu

  Fixes kserve/kserve#5330 (documentation requirement)