### PR TITLE
fix: wrong url for quick installation

### DIFF
--- a/docs/getting-started/quickstart-guide.md
+++ b/docs/getting-started/quickstart-guide.md
@@ -240,12 +240,12 @@ Choose either Standard mode or Knative mode:
 
 ```bash
 # Option A: Standard Mode Dependencies
-curl -s "https://raw.githubusercontent.com/kserve/kserve/refs/tags/v0.17.0/install/v0.17.0/kserve-standard-mode-dependency-install.sh" | bash
+curl -fsSL https://github.com/kserve/kserve/releases/download/v0.17.0/kserve-standard-mode-dependency-install.sh | bash
 
 # OR
 
 # Option B: Knative Mode Dependencies
-curl -s "https://raw.githubusercontent.com/kserve/kserve/refs/tags/v0.17.0/install/v0.17.0/kserve-knative-mode-dependency-install.sh" | bash
+curl -fsSL https://github.com/kserve/kserve/releases/download/v0.17.0/kserve-knative-mode-dependency-install.sh | bash
 ```
 
 **Step 2: Install All Components**
@@ -254,16 +254,16 @@ After installing dependencies above, run these commands:
 
 ```bash
 # Install LLMInferenceService Dependencies
-curl -s "https://raw.githubusercontent.com/kserve/kserve/refs/tags/v0.17.0/install/v0.17.0/llmisvc-dependency-install.sh" | bash
+curl -fsSL https://github.com/kserve/kserve/releases/download/v0.17.0/llmisvc-dependency-install.sh | bash
+
 
 # Install CRDs
-kubectl apply -f https://raw.githubusercontent.com/kserve/kserve/refs/tags/v0.17.0/install/v0.17.0/kserve-crds.yaml
-
+kubectl apply -f https://github.com/kserve/kserve/releases/download/v0.17.0/kserve-crds.yaml
 # Install Controllers
-kubectl apply -f https://raw.githubusercontent.com/kserve/kserve/refs/tags/v0.17.0/install/v0.17.0/kserve.yaml
+kubectl apply -f https://github.com/kserve/kserve/releases/download/v0.17.0/kserve.yaml
 
 # Install ClusterServingRuntimes/LLMIsvcConfigs
-kubectl apply -f https://raw.githubusercontent.com/kserve/kserve/refs/tags/v0.17.0/install/v0.17.0/kserve-cluster-resources.yaml
+kubectl apply -f https://github.com/kserve/kserve/releases/download/v0.17.0/kserve-cluster-resources.yaml
 ```
 
 </details>
@@ -305,22 +305,20 @@ Install only infrastructure dependencies without KServe components.
 **Standard Mode Dependencies**:
 
 ```bash
-curl -s "https://raw.githubusercontent.com/kserve/kserve/refs/tags/v0.17.0/install/v0.17.0/kserve-standard-mode-dependency-install.sh" | bash
+curl -fsSL https://github.com/kserve/kserve/releases/download/v0.17.0/kserve-standard-mode-dependency-install.sh | bash
 ```
 
 **Knative Mode Dependencies**:
 
 ```bash
-curl -s "https://raw.githubusercontent.com/kserve/kserve/refs/tags/v0.17.0/install/v0.17.0/kserve-knative-mode-dependency-install.sh" | bash
+curl -fsSL https://github.com/kserve/kserve/releases/download/v0.17.0/kserve-knative-mode-dependency-install.sh | bash
 ```
 
 **LLMIsvc Dependencies**:
 
 ```bash
-curl -s "https://raw.githubusercontent.com/kserve/kserve/refs/tags/v0.17.0/install/v0.17.0/llmisvc-dependency-install.sh" | bash
+curl -fsSL https://github.com/kserve/kserve/releases/download/v0.17.0/llmisvc-dependency-install.sh | bash
 ```
-
-
 </details>
 
 <details>

--- a/docs/getting-started/quickstart-guide.md
+++ b/docs/getting-started/quickstart-guide.md
@@ -130,10 +130,10 @@ Install KServe controller only without additional components.
 
 ```
 # Standard mode
-curl -s "https://raw.githubusercontent.com/kserve/kserve/refs/tags/v0.17.0/install/v0.17.0/kserve-standard-mode-full-install-with-manifests.sh" | bash
+curl -s "https://raw.githubusercontent.com/kserve/kserve/refs/heads/master/install/v0.17.0/kserve-standard-mode-full-install-with-manifests.sh" | bash
 
 # Knative mode (serverless)
-curl -s "https://raw.githubusercontent.com/kserve/kserve/refs/tags/v0.17.0/install/v0.17.0/kserve-knative-mode-full-install-with-manifests.sh" | bash
+curl -s "https://raw.githubusercontent.com/kserve/kserve/refs/heads/master/install/v0.17.0/kserve-knative-mode-full-install-with-manifests.sh" | bash
 ```
 </details>
 
@@ -203,7 +203,7 @@ Install LLMInferenceService controller only for Generative AI model serving.
 <summary>Using Quick Install Script</summary>
 
 ```
-curl -s "https://raw.githubusercontent.com/kserve/kserve/refs/tags/v0.17.0/install/v0.17.0/llmisvc-full-install-with-manifests.sh" | bash
+curl -s "https://raw.githubusercontent.com/kserve/kserve/refs/heads/master/install/v0.17.0/llmisvc-full-install-with-manifests.sh" | bash
 ```
 </details>
 

--- a/versioned_docs/version-0.17/getting-started/quickstart-guide.md
+++ b/versioned_docs/version-0.17/getting-started/quickstart-guide.md
@@ -240,12 +240,12 @@ Choose either Standard mode or Knative mode:
 
 ```bash
 # Option A: Standard Mode Dependencies
-curl -s "https://raw.githubusercontent.com/kserve/kserve/refs/tags/v0.17.0/install/v0.17.0/kserve-standard-mode-dependency-install.sh" | bash
+curl -fsSL https://github.com/kserve/kserve/releases/download/v0.17.0/kserve-standard-mode-dependency-install.sh | bash
 
 # OR
 
 # Option B: Knative Mode Dependencies
-curl -s "https://raw.githubusercontent.com/kserve/kserve/refs/tags/v0.17.0/install/v0.17.0/kserve-knative-mode-dependency-install.sh" | bash
+curl -fsSL https://github.com/kserve/kserve/releases/download/v0.17.0/kserve-knative-mode-dependency-install.sh | bash
 ```
 
 **Step 2: Install All Components**
@@ -254,16 +254,16 @@ After installing dependencies above, run these commands:
 
 ```bash
 # Install LLMInferenceService Dependencies
-curl -s "https://raw.githubusercontent.com/kserve/kserve/refs/tags/v0.17.0/install/v0.17.0/llmisvc-dependency-install.sh" | bash
+curl -fsSL https://github.com/kserve/kserve/releases/download/v0.17.0/llmisvc-dependency-install.sh | bash
+
 
 # Install CRDs
-kubectl apply -f https://raw.githubusercontent.com/kserve/kserve/refs/tags/v0.17.0/install/v0.17.0/kserve-crds.yaml
-
+kubectl apply -f https://github.com/kserve/kserve/releases/download/v0.17.0/kserve-crds.yaml
 # Install Controllers
-kubectl apply -f https://raw.githubusercontent.com/kserve/kserve/refs/tags/v0.17.0/install/v0.17.0/kserve.yaml
+kubectl apply -f https://github.com/kserve/kserve/releases/download/v0.17.0/kserve.yaml
 
 # Install ClusterServingRuntimes/LLMIsvcConfigs
-kubectl apply -f https://raw.githubusercontent.com/kserve/kserve/refs/tags/v0.17.0/install/v0.17.0/kserve-cluster-resources.yaml
+kubectl apply -f https://github.com/kserve/kserve/releases/download/v0.17.0/kserve-cluster-resources.yaml
 ```
 
 </details>
@@ -305,19 +305,19 @@ Install only infrastructure dependencies without KServe components.
 **Standard Mode Dependencies**:
 
 ```bash
-curl -s "https://raw.githubusercontent.com/kserve/kserve/refs/tags/v0.17.0/install/v0.17.0/kserve-standard-mode-dependency-install.sh" | bash
+curl -fsSL https://github.com/kserve/kserve/releases/download/v0.17.0/kserve-standard-mode-dependency-install.sh | bash
 ```
 
 **Knative Mode Dependencies**:
 
 ```bash
-curl -s "https://raw.githubusercontent.com/kserve/kserve/refs/tags/v0.17.0/install/v0.17.0/kserve-knative-mode-dependency-install.sh" | bash
+curl -fsSL https://github.com/kserve/kserve/releases/download/v0.17.0/kserve-knative-mode-dependency-install.sh | bash
 ```
 
 **LLMIsvc Dependencies**:
 
 ```bash
-curl -s "https://raw.githubusercontent.com/kserve/kserve/refs/tags/v0.17.0/install/v0.17.0/llmisvc-dependency-install.sh" | bash
+curl -fsSL https://github.com/kserve/kserve/releases/download/v0.17.0/llmisvc-dependency-install.sh | bash
 ```
 
 

--- a/versioned_docs/version-0.17/getting-started/quickstart-guide.md
+++ b/versioned_docs/version-0.17/getting-started/quickstart-guide.md
@@ -130,10 +130,10 @@ Install KServe controller only without additional components.
 
 ```
 # Standard mode
-curl -s "https://raw.githubusercontent.com/kserve/kserve/refs/tags/v0.17.0/install/v0.17.0/kserve-standard-mode-full-install-with-manifests.sh" | bash
+curl -s "https://raw.githubusercontent.com/kserve/kserve/refs/heads/master/install/v0.17.0/kserve-standard-mode-full-install-with-manifests.sh" | bash
 
 # Knative mode (serverless)
-curl -s "https://raw.githubusercontent.com/kserve/kserve/refs/tags/v0.17.0/install/v0.17.0/kserve-knative-mode-full-install-with-manifests.sh" | bash
+curl -s "https://raw.githubusercontent.com/kserve/kserve/refs/heads/master/install/v0.17.0/kserve-knative-mode-full-install-with-manifests.sh" | bash
 ```
 </details>
 
@@ -203,7 +203,7 @@ Install LLMInferenceService controller only for Generative AI model serving.
 <summary>Using Quick Install Script</summary>
 
 ```
-curl -s "https://raw.githubusercontent.com/kserve/kserve/refs/tags/v0.17.0/install/v0.17.0/llmisvc-full-install-with-manifests.sh" | bash
+curl -s "https://raw.githubusercontent.com/kserve/kserve/refs/heads/master/install/v0.17.0/llmisvc-full-install-with-manifests.sh" | bash
 ```
 </details>
 


### PR DESCRIPTION
## Summary
- Fix wrong URLs for quick install scripts in quickstart guide
- Change `refs/tags` to `refs/heads/master` for install script URLs
- Change `raw.githubusercontent.com` to `github.com/releases/download` for dependency install URLs
- Apply fixes to both docs/ and versioned_docs/version-0.17/