### PR TITLE
docs: add pathMatchType to ingress configuration guide

### DIFF
--- a/docs/admin-guide/configurations.md
+++ b/docs/admin-guide/configurations.md
@@ -43,6 +43,7 @@ data:
         "disableIstioVirtualHost": false,
         "disableIngressCreation": false,
         "disableHTTPRouteTimeout": false,
+        "pathMatchType": "",
         "pathTemplate": "/serving/{{ .Namespace }}/{{ .Name }}"
     }
 ```
@@ -193,6 +194,17 @@ which would otherwise cause HTTPRoutes to be rejected with `Accepted=False/Unsup
 - **Global key:** `disableHTTPRouteTimeout`
 - **Possible values:** `true`, `false`
 - **Default:** `false`
+
+### Path Match Type
+
+Controls the path match type used in HTTPRoute rules when using Gateway API.
+Set to `"PathPrefix"` for Gateway controllers (e.g. GKE Gateway) that do not support `RegularExpression` path matches,
+which would otherwise cause HTTPRoutes to be rejected with `GWCER104: Paths must start with '/' character`.
+When empty or unset, the default `RegularExpression` matching is used.
+
+- **Global key:** `pathMatchType`
+- **Possible values:** `""`, `"PathPrefix"`
+- **Default:** `""`
 
 ### Path Template
 


### PR DESCRIPTION
## Summary

Add documentation for the new `pathMatchType` config flag in the ingress configuration guide.

This flag allows operators to switch from `RegularExpression` to `PathPrefix` path matching in HTTPRoutes, resolving GKE Gateway incompatibility where regex paths are rejected with `GWCER104`.

Companion to kserve/kserve#5347.

## Changes

- `docs/admin-guide/configurations.md` — Added `pathMatchType` to the example config block and a new "Path Match Type" section describing the flag, possible values, and default.
