### PR TITLE
docs: fix v0.17 Helm chart references in admin guides

### DIFF
--- a/docs/admin-guide/gatewayapi-migration.md
+++ b/docs/admin-guide/gatewayapi-migration.md
@@ -113,7 +113,7 @@ First, enable the Gateway API feature:
 If using Helm, set the following values:
 
 ```bash
-helm upgrade kserve oci://ghcr.io/kserve/charts/kserve --version v0.17.0 \
+helm upgrade kserve oci://ghcr.io/kserve/charts/kserve-resources --version v0.17.0 \
   --set kserve.controller.gateway.ingressGateway.enableGatewayApi=true
 ```
 
@@ -130,7 +130,7 @@ Next, specify the Gateway resource name and namespace in the format `<gateway na
 If using Helm, set:
 
 ```bash
-helm upgrade kserve oci://ghcr.io/kserve/charts/kserve --version v0.17.0 \
+helm upgrade kserve oci://ghcr.io/kserve/charts/kserve-resources --version v0.17.0 \
   --set kserve.controller.gateway.ingressGateway.kserveGateway=kserve/kserve-ingress-gateway
 ```
 

--- a/docs/admin-guide/kubernetes-deployment.md
+++ b/docs/admin-guide/kubernetes-deployment.md
@@ -168,7 +168,7 @@ helm install kserve-crd oci://ghcr.io/kserve/charts/kserve-crd --version v0.17.0
 Set the `kserve.controller.deploymentMode` to `Standard` and configure the Gateway API:
 
 ```bash
-helm install kserve oci://ghcr.io/kserve/charts/kserve --version v0.17.0 \
+helm install kserve oci://ghcr.io/kserve/charts/kserve-resources --version v0.17.0 \
   --set kserve.controller.deploymentMode=Standard \
   --set kserve.controller.gateway.ingressGateway.enableGatewayApi=true \
   --set kserve.controller.gateway.ingressGateway.kserveGateway=kserve/kserve-ingress-gateway
@@ -218,7 +218,7 @@ helm install kserve-crd oci://ghcr.io/kserve/charts/kserve-crd --version v0.17.0
 Set the `kserve.controller.deploymentMode` to `Standard` and configure the Ingress class:
 
 ```bash
-helm install kserve oci://ghcr.io/kserve/charts/kserve --version v0.17.0 \
+helm install kserve oci://ghcr.io/kserve/charts/kserve-resources --version v0.17.0 \
   --set kserve.controller.deploymentMode=Standard \
   --set kserve.controller.gateway.ingressGateway.className=istio
 ```

--- a/docs/admin-guide/serverless/serverless.md
+++ b/docs/admin-guide/serverless/serverless.md
@@ -76,7 +76,7 @@ helm install kserve-crd oci://ghcr.io/kserve/charts/kserve-crd --version v0.17.0
 
 Install KServe Resources
 ```bash
-helm install kserve oci://ghcr.io/kserve/charts/kserve --version v0.17.0
+helm install kserve oci://ghcr.io/kserve/charts/kserve-resources --version v0.17.0
 ```
 
 ### Install using YAML

--- a/versioned_docs/version-0.17/admin-guide/gatewayapi-migration.md
+++ b/versioned_docs/version-0.17/admin-guide/gatewayapi-migration.md
@@ -113,7 +113,7 @@ First, enable the Gateway API feature:
 If using Helm, set the following values:
 
 ```bash
-helm upgrade kserve oci://ghcr.io/kserve/charts/kserve --version v0.17.0 \
+helm upgrade kserve oci://ghcr.io/kserve/charts/kserve-resources --version v0.17.0 \
   --set kserve.controller.gateway.ingressGateway.enableGatewayApi=true
 ```
 
@@ -130,7 +130,7 @@ Next, specify the Gateway resource name and namespace in the format `<gateway na
 If using Helm, set:
 
 ```bash
-helm upgrade kserve oci://ghcr.io/kserve/charts/kserve --version v0.17.0 \
+helm upgrade kserve oci://ghcr.io/kserve/charts/kserve-resources --version v0.17.0 \
   --set kserve.controller.gateway.ingressGateway.kserveGateway=kserve/kserve-ingress-gateway
 ```
 

--- a/versioned_docs/version-0.17/admin-guide/kubernetes-deployment.md
+++ b/versioned_docs/version-0.17/admin-guide/kubernetes-deployment.md
@@ -168,7 +168,7 @@ helm install kserve-crd oci://ghcr.io/kserve/charts/kserve-crd --version v0.17.0
 Set the `kserve.controller.deploymentMode` to `Standard` and configure the Gateway API:
 
 ```bash
-helm install kserve oci://ghcr.io/kserve/charts/kserve --version v0.17.0 \
+helm install kserve oci://ghcr.io/kserve/charts/kserve-resources --version v0.17.0 \
   --set kserve.controller.deploymentMode=Standard \
   --set kserve.controller.gateway.ingressGateway.enableGatewayApi=true \
   --set kserve.controller.gateway.ingressGateway.kserveGateway=kserve/kserve-ingress-gateway
@@ -218,7 +218,7 @@ helm install kserve-crd oci://ghcr.io/kserve/charts/kserve-crd --version v0.17.0
 Set the `kserve.controller.deploymentMode` to `Standard` and configure the Ingress class:
 
 ```bash
-helm install kserve oci://ghcr.io/kserve/charts/kserve --version v0.17.0 \
+helm install kserve oci://ghcr.io/kserve/charts/kserve-resources --version v0.17.0 \
   --set kserve.controller.deploymentMode=Standard \
   --set kserve.controller.gateway.ingressGateway.className=istio
 ```

--- a/versioned_docs/version-0.17/admin-guide/serverless/serverless.md
+++ b/versioned_docs/version-0.17/admin-guide/serverless/serverless.md
@@ -76,7 +76,7 @@ helm install kserve-crd oci://ghcr.io/kserve/charts/kserve-crd --version v0.17.0
 
 Install KServe Resources
 ```bash
-helm install kserve oci://ghcr.io/kserve/charts/kserve --version v0.17.0
+helm install kserve oci://ghcr.io/kserve/charts/kserve-resources --version v0.17.0
 ```
 
 ### Install using YAML


### PR DESCRIPTION
## Summary
- update current admin-guide Helm examples to use the renamed `kserve-resources` chart for v0.17
- mirror the same fixes in the versioned v0.17 docs
- correct the remaining Gateway API migration commands that still pointed at the removed `kserve` chart

Fixes #628

## Validation
- ran `npm run build`
- build completed successfully and generated the site
- Docusaurus reported pre-existing broken-anchor warnings elsewhere in the docs tree; this change does not add new warnings or build errors