### PR TITLE
fix: wrong inferenceservice-config path in install page

### DIFF
--- a/docs/install/kserve-install.md
+++ b/docs/install/kserve-install.md
@@ -45,7 +45,7 @@ kubectl apply -k config/overlays/addons/kserve
 ```bash
 # Set deployment mode to Standard
 # Edit the inferenceservice ConfigMap
-vi config/default/configmap/inferenceservice.yaml
+vi config/configmap/inferenceservice.yaml
 
 # Change the deploy section to:
 # deploy: |

--- a/versioned_docs/version-0.17/install/kserve-install.md
+++ b/versioned_docs/version-0.17/install/kserve-install.md
@@ -45,7 +45,7 @@ kubectl apply -k config/overlays/addons/kserve
 ```bash
 # Set deployment mode to Standard
 # Edit the inferenceservice ConfigMap
-vi config/default/configmap/inferenceservice.yaml
+vi config/configmap/inferenceservice.yaml
 
 # Change the deploy section to:
 # deploy: |


### PR DESCRIPTION
## Proposed Changes

The Standard deployment instructions point to a non-existing path in the
repository. Fix to the right path.

