### PR TITLE
Port forward command at genai-first-llmisvc.md fixed

### DIFF
--- a/docs/getting-started/genai-first-llmisvc.md
+++ b/docs/getting-started/genai-first-llmisvc.md
@@ -103,7 +103,7 @@ Once the service is ready, test it with a completion request:
 # Get the Gateway URL if you have external LB not KIND cloud-provider
 # GATEWAY_URL=$(kubectl get llminferenceservice facebook-opt-125m-single -n llm-demo -o jsonpath='{.status.url}')
 
-kubectl port-forward $(oc get svc -n envoy-gateway-system -l serving.kserve.io/gateway=kserve-ingress-gateway --no-headers -o name)  -n envoy-gateway-system 8001:80 &
+kubectl port-forward $(kubectl get svc -n envoy-gateway-system -l serving.kserve.io/gateway=kserve-ingress-gateway --no-headers -o name)  -n envoy-gateway-system 8001:80 &
 
 # Send a completion request
 curl -sS -X POST http://localhost:8001/llm-demo/facebook-opt-125m-single/v1/completions   \

--- a/versioned_docs/version-0.16/getting-started/genai-first-llmisvc.md
+++ b/versioned_docs/version-0.16/getting-started/genai-first-llmisvc.md
@@ -103,7 +103,7 @@ Once the service is ready, test it with a completion request:
 # Get the Gateway URL if you have external LB not KIND cloud-provider
 # GATEWAY_URL=$(kubectl get llminferenceservice facebook-opt-125m-single -n llm-demo -o jsonpath='{.status.url}')
 
-kubectl port-forward $(oc get svc -n envoy-gateway-system -l serving.kserve.io/gateway=kserve-ingress-gateway --no-headers -o name)  -n envoy-gateway-system 8001:80 &
+kubectl port-forward $(kubectl get svc -n envoy-gateway-system -l serving.kserve.io/gateway=kserve-ingress-gateway --no-headers -o name)  -n envoy-gateway-system 8001:80 &
 
 # Send a completion request
 curl -sS -X POST http://localhost:8001/llm-demo/facebook-opt-125m-single/v1/completions   \

--- a/versioned_docs/version-0.17/getting-started/genai-first-llmisvc.md
+++ b/versioned_docs/version-0.17/getting-started/genai-first-llmisvc.md
@@ -103,7 +103,7 @@ Once the service is ready, test it with a completion request:
 # Get the Gateway URL if you have external LB not KIND cloud-provider
 # GATEWAY_URL=$(kubectl get llminferenceservice facebook-opt-125m-single -n llm-demo -o jsonpath='{.status.url}')
 
-kubectl port-forward $(oc get svc -n envoy-gateway-system -l serving.kserve.io/gateway=kserve-ingress-gateway --no-headers -o name)  -n envoy-gateway-system 8001:80 &
+kubectl port-forward $(kubectl get svc -n envoy-gateway-system -l serving.kserve.io/gateway=kserve-ingress-gateway --no-headers -o name)  -n envoy-gateway-system 8001:80 &
 
 # Send a completion request
 curl -sS -X POST http://localhost:8001/llm-demo/facebook-opt-125m-single/v1/completions   \


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`kserve/website` GitHub repository](https://github.com/kserve/website).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/help/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/help/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the KServe blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, add the corresponding "cherrypick-0.X"
label to the original PR; for example, "cherrypick-0.12".
Best practice is to open a PR for the cherry-pick yourself after your original PR has been merged
into the main branch.
After the cherry-pick PR has merged, remove the cherry-pick label from the original PR.

For all resources for contributing to the KServe documentation, see the
[KServe contributor's guide](/docs/help/contributor/mkdocs-contributor-guide.md).

 -->



## Proposed Changes <!-- Describe the changes the PR makes. -->

At step 4 in the guide, port-forward command uses `kubectl` instead of `oc`.
Fixes issue #666 


