### PR TITLE
docs: update footer to LF Projects compliance requirements

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -229,17 +229,7 @@ const config: Config = {
           ],
         },
       ],
-<<<<<<< HEAD
-      copyright: `Copyright © ${new Date().getFullYear()} The KServe Authors. All rights reserved. <br/> The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our <a
-            href="https://www.linuxfoundation.org/trademark-usage"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="underline">
-            Trademark Usage page.
-          </a>`,
-=======
       copyright: `Copyright © ${new Date().getFullYear()} KServe, a Series of LF Projects, LLC. For web site terms of use, trademark policy and other project policies please see <a href="https://lfprojects.org/policies/" target="_blank" rel="noopener noreferrer">https://lfprojects.org/policies/</a>.`,
->>>>>>> 2ec50b6d (docs: update footer to LF Projects compliance requirements)
     },
     prism: {
       theme: prismThemes.github,

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -229,6 +229,7 @@ const config: Config = {
           ],
         },
       ],
+<<<<<<< HEAD
       copyright: `Copyright © ${new Date().getFullYear()} The KServe Authors. All rights reserved. <br/> The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our <a
             href="https://www.linuxfoundation.org/trademark-usage"
             target="_blank"
@@ -236,6 +237,9 @@ const config: Config = {
             className="underline">
             Trademark Usage page.
           </a>`,
+=======
+      copyright: `Copyright © ${new Date().getFullYear()} KServe, a Series of LF Projects, LLC. For web site terms of use, trademark policy and other project policies please see <a href="https://lfprojects.org/policies/" target="_blank" rel="noopener noreferrer">https://lfprojects.org/policies/</a>.`,
+>>>>>>> 2ec50b6d (docs: update footer to LF Projects compliance requirements)
     },
     prism: {
       theme: prismThemes.github,


### PR DESCRIPTION
## Summary
Updates the website footer to comply with CNCF requirements for projects converted to Series of LF Projects, LLC.

## Changes
- Updated copyright to include "Series of LF Projects, LLC" wording
- Added link to LF Projects policies page (https://lfprojects.org/policies/)
- Removed previous trademark usage reference

## Acceptance Criteria from #665
- ✅ Footer links to LF Projects policies
- ✅ Footer includes "A Series of LF Projects, LLC" wording
- ⏳ Update is deployed to the public website (after merge)

Fixes #665

## Testing
- ✅ Build passes successfully
- ✅ Footer text matches required format from https://lfprojects.org/policies/

Signed-off-by: Alexa Griffith <agriffith96@gmail.com>