### PR TITLE
Add kapa.ai AI assistant widget

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -50,6 +50,18 @@ const config: Config = {
     '@orama/plugin-docusaurus-v3',
   ],
 
+  // Add kapa.ai AI assistant widget
+  scripts: [
+    {
+      src: 'https://widget.kapa.ai/kapa-widget.bundle.js',
+      'data-website-id': '054b6efc-8335-4caf-b88d-4f001355cc8d',
+      'data-project-name': 'KServe',
+      'data-project-color': '#588be8',
+      'data-project-logo': 'https://kserve.github.io/website/img/kserve-logo.png',
+      async: true,
+    },
+  ],
+
   presets: [
     [
       'classic',


### PR DESCRIPTION
## Summary
- Adds kapa.ai AI assistant widget to the KServe documentation website
- Widget is configured with KServe branding (color #588be8 and logo)
- Loads asynchronously to avoid impacting page performance

## Configuration Details
- **Project Name**: KServe
- **Brand Color**: #588be8
- **Logo**: https://kserve.github.io/website/img/kserve-logo.png

## Next Steps
After merging, enable these domains in the kapa.ai dashboard (app.kapa.ai → Integrations):
- `https://kserve.github.io/website/` (production)
- `^https://.*\.netlify\.app$` (Netlify preview deployments)

## Test Plan
- [x] Widget configuration added to `docusaurus.config.ts`
- [x] Test widget appears on localhost:3000
- [ ] After merge and domain activation, verify widget on production site
- [ ] Verify widget functionality (ask questions, get AI responses)

🤖 Generated with [Claude Code](https://claude.com/claude-code)