### PR TITLE
docs(llmisvc): add referenced HTTPRoute and InferencePool examples

### DIFF
--- a/docs/model-serving/generative-inference/llmisvc/llmisvc-configuration.md
+++ b/docs/model-serving/generative-inference/llmisvc/llmisvc-configuration.md
@@ -409,6 +409,19 @@ spec:
     route: {}  # Auto-generated routing rules
 ```
 
+#### Referenced HTTPRoute
+
+```yaml
+spec:
+  router:
+    route:
+      http:
+        refs:
+          - name: my-custom-http-route
+```
+
+Use an existing, user-managed HTTPRoute instead of having the controller create one. The controller validates that the referenced HTTPRoute exists but does not modify it. This is useful for advanced routing setups like canary deployments or custom traffic splitting.
+
 #### Custom HTTPRoute Spec
 
 ```yaml
@@ -424,6 +437,8 @@ spec:
                 - name: my-backend-service
                   port: 8000
 ```
+
+`spec` and `refs` are mutually exclusive - use `refs` to bring your own HTTPRoute, or `spec` to have the controller create one with your custom rules.
 
 #### Real-world Use Cases
 
@@ -496,6 +511,19 @@ KServe creates:
 - Scheduler Deployment (EPP)
 - Scheduler Service
 
+#### Referenced InferencePool
+
+```yaml
+spec:
+  router:
+    scheduler:
+      pool:
+        ref:
+          name: my-existing-pool
+```
+
+Use an existing, user-managed InferencePool instead of having the controller create one. When a pool `ref` is provided, the controller does not create an EPP deployment or InferencePool - it only creates an InferenceModel pointing to the referenced pool.
+
 #### Custom Scheduler with Pool
 
 ```yaml
@@ -509,6 +537,8 @@ spec:
               app: workload
           targetPort: 8000
 ```
+
+`pool.spec` and `pool.ref` are mutually exclusive - use `ref` to bring your own InferencePool, or `spec` to have the controller create one with custom settings.
 ---
 
 ## Parallelism Specification


### PR DESCRIPTION
## Summary

- Adds "Referenced HTTPRoute" example (`route.http.refs`) to the HTTPRoute Configuration section
- Adds "Referenced InferencePool" example (`scheduler.pool.ref`) to the Scheduler Configuration section
- Documents mutual exclusivity between `spec` and `refs`/`ref` patterns for both components
- Explains when to use each pattern (managed vs bring-your-own)

## Motivation

The router configuration section documented managed (`{}`) and custom spec (`.spec`) patterns but was missing the "bring your own" ref pattern. The API supports referencing existing user-managed HTTPRoute and InferencePool resources ([types.go#L234-L244](https://github.com/kserve/kserve/blob/d5aea2c6d8f2f2c8dcf22897e23e5d929cf654dd/pkg/apis/serving/v1alpha2/llm_inference_service_types.go#L234-L244)), but users had no documentation for this pattern.

The Gateway section already had the referenced pattern documented (`gateway.refs`), so this brings HTTPRoute and Scheduler to parity.

## Test plan

- [ ] Verify examples render correctly in the configuration page
- [ ] Verify `npm run build` succeeds