### PR TITLE
docs: add CPU inference deployment guide for text generation

### DIFF
--- a/docs/model-serving/generative-inference/overview.md
+++ b/docs/model-serving/generative-inference/overview.md
@@ -101,6 +101,23 @@ spec:
 
 This automatic selection ensures optimal performance without requiring manual configuration of container images.
 
+### CPU Deployment Configuration
+
+When running on CPU, there are additional environment variables that control performance. Set these in the `env` section of your InferenceService predictor:
+
+| Variable | Description |
+|----------|-------------|
+| `VLLM_CPU_KVCACHE_SPACE` | Amount of memory in GiB to allocate for the KV cache. Higher values allow longer context windows. Example: `"4"` for a 0.5B model, `"8"` for a 3B model. |
+| `VLLM_CPU_OMP_THREADS_BIND` | Controls how OpenMP threads are bound to CPU cores. Set to `"auto"` to let vLLM detect the best binding. This prevents thread migration across NUMA nodes. |
+| `VLLM_ENABLE_V1_MULTIPROCESSING` | Set to `"0"` to run in single process mode. Recommended for CPU deployments to avoid inter-process communication overhead. |
+| `OMP_NUM_THREADS` | Number of OpenMP threads to use. Should match the number of CPU cores allocated to the container. |
+
+:::warning[CPU dtype]
+Use `--dtype=bfloat16` for CPU deployments. The default `float16` can cause numerical instability on CPUs without native FP16 support. If `bfloat16` is not available on your hardware, use `float32` instead.
+:::
+
+For a complete CPU deployment example, see the [text generation guide](tasks/text-generation/text-generation.md).
+
 ## Supported Generative Tasks
 
 The Hugging Face runtime supports the following generative tasks:

--- a/docs/model-serving/generative-inference/tasks/text-generation/text-generation.md
+++ b/docs/model-serving/generative-inference/tasks/text-generation/text-generation.md
@@ -8,15 +8,14 @@ import TabItem from '@theme/TabItem';
 
 # Text Generation with Large Language Models
 
-Text generation is a fundamental capability of Large Language Models (LLMs) that enables a wide range of applications including chatbots, content creation, summarization, and more. This guide demonstrates how to deploy Llama3, a powerful open-source LLM, using KServe's flexible inference runtimes.
+This guide shows how to deploy LLMs for text generation using KServe on GPU and CPU environments.
 
 ## Prerequisites
 
-Before getting started, ensure you have:
-
 - A Kubernetes cluster with [KServe installed](../../../../getting-started/quickstart-guide.md).
-- GPU resources available for model inference (this example uses NVIDIA GPUs).
-- A Hugging Face account with [access token](https://huggingface.co/docs/hub/en/security-tokens) (required for downloading Llama3 model).
+- For GPU: NVIDIA GPU resources available on your nodes.
+- For CPU: nodes with enough CPU and memory. CPUs with AVX-512 instruction support are recommended.
+- A [Hugging Face access token](https://huggingface.co/docs/hub/en/security-tokens) to download gated models like Llama3.
 
 ## Create a Hugging Face Token Secret
 
@@ -149,6 +148,65 @@ Save this to a file (e.g., `llama3-hf.yaml`) and apply it:
 
 ```bash
 kubectl apply -f llama3-hf.yaml
+```
+</TabItem>
+<TabItem value="vllm-cpu" label="vLLM Backend (CPU)">
+
+For clusters without GPUs, KServe can serve models using the vLLM CPU backend. Use a smaller model that fits in memory, such as `Qwen2-0.5B-Instruct`.
+
+:::warning[CPU Performance]
+CPU inference is slower than GPU. Expect 5 to 20 tokens per second depending on model size and hardware. Use smaller models (under 3B parameters) for acceptable latency.
+:::
+
+```yaml title="qwen-cpu.yaml"
+apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  name: qwen-cpu
+spec:
+  predictor:
+    model:
+      modelFormat:
+        name: huggingface
+      args:
+        - --model_name=qwen2
+        - --dtype=bfloat16
+        - --max-model-len=2048
+      storageUri: hf://Qwen/Qwen2-0.5B-Instruct
+      env:
+        - name: VLLM_CPU_KVCACHE_SPACE
+          value: "4"
+        - name: VLLM_CPU_OMP_THREADS_BIND
+          value: "auto"
+        - name: VLLM_ENABLE_V1_MULTIPROCESSING
+          value: "0"
+      resources:
+        requests:
+          cpu: "4"
+          memory: 8Gi
+        limits:
+          cpu: "8"
+          memory: 16Gi
+```
+
+:::note
+KServe auto-selects the CPU container image when no `nvidia.com/gpu` resource is requested. You do not need to specify the image manually.
+:::
+
+Key configuration points:
+
+| Parameter                        | Value      | Why                                                                                         |
+| -------------------------------- | ---------- | ------------------------------------------------------------------------------------------- |
+| `--dtype=bfloat16`               | bfloat16   | Stable on CPU. Do not use `float16` which can cause numerical instability without GPU.       |
+| `--max-model-len=2048`           | 2048       | Limits context window to reduce memory usage on CPU. Increase if your workload needs more.   |
+| `VLLM_CPU_KVCACHE_SPACE`        | `4`        | Allocates 4 GiB for the KV cache. Increase for longer contexts or larger models.             |
+| `VLLM_CPU_OMP_THREADS_BIND`     | `auto`     | Binds OpenMP threads to CPU cores. Prevents thread migration and NUMA contention.            |
+| `VLLM_ENABLE_V1_MULTIPROCESSING` | `0`        | Runs in single process mode. Recommended for CPU to avoid IPC overhead.                      |
+
+Save this to a file (e.g., `qwen-cpu.yaml`) and apply it:
+
+```bash
+kubectl apply -f qwen-cpu.yaml
 ```
 </TabItem>
 </Tabs>
@@ -315,10 +373,13 @@ data: [DONE]
 
 Common issues and solutions:
 
-- **Init:OOMKilled**: This indicates that the storage initializer exceeded the memory limits. You can try increasing the memory limits in the `ClusterStorageContainer`.
-- **OOM errors**: Increase the memory allocation in the InferenceService specification
-- **Pending Deployment**: Ensure your cluster has enough GPU resources available
-- **Model not found**: Double-check your Hugging Face token and model ID
+- **Init:OOMKilled**: The storage initializer ran out of memory. Increase the memory limits in the `ClusterStorageContainer`.
+- **OOM errors**: Increase the memory allocation in the InferenceService specification.
+- **Pending Deployment**: Check that your cluster has enough GPU (or CPU/memory) resources available.
+- **Model not found**: Verify your Hugging Face token and model ID.
+- **Illegal instruction (CPU)**: Your CPU does not support the required instruction set. vLLM CPU images work best with AVX-512. Check with `lscpu | grep avx512`.
+- **Slow startup (CPU)**: CPU model loading takes longer than GPU. A 0.5B model may take 1 to 2 minutes to become ready. A 3B model may take 5 minutes or more.
+- **Numerical errors (CPU)**: Make sure you set `--dtype=bfloat16`. Using `float16` on CPU can produce incorrect results.
 
 ## Next Steps
 

--- a/docs/model-serving/generative-inference/tasks/text-generation/text-generation.md
+++ b/docs/model-serving/generative-inference/tasks/text-generation/text-generation.md
@@ -12,6 +12,8 @@ This guide shows how to deploy LLMs for text generation using KServe on GPU and 
 
 ## Prerequisites
 
+Before getting started, ensure you have:
+
 - A Kubernetes cluster with [KServe installed](../../../../getting-started/quickstart-guide.md).
 - For GPU: NVIDIA GPU resources available on your nodes.
 - For CPU: nodes with enough CPU and memory. CPUs with AVX-512 instruction support are recommended.


### PR DESCRIPTION
## What this PR does / why we need it

The text generation guide and runtime overview only show GPU deployment
examples (Llama3 with nvidia.com/gpu). Users deploying on CPU-only
clusters have no documentation for the environment variables and dtype
configuration needed to run vLLM on CPU.

This PR adds:

- A "vLLM Backend (CPU)" tab to the text generation guide with a
  working InferenceService example using Qwen2-0.5B-Instruct
- Documentation for CPU-specific environment variables:
  VLLM_CPU_KVCACHE_SPACE, VLLM_CPU_OMP_THREADS_BIND,
  VLLM_ENABLE_V1_MULTIPROCESSING, OMP_NUM_THREADS
- A warning about using --dtype=bfloat16 on CPU instead of float16
- CPU-specific troubleshooting entries (AVX-512, startup times,
  numerical errors)
- A "CPU Deployment Configuration" section in the runtime overview

## Which issue(s) this PR fixes

Related to https://github.com/kserve/kserve/issues/4382 (vLLM CPU
test enablement — this PR covers the documentation side)

## Feature validation / testing

- Site builds successfully with `npx docusaurus build`
- CPU tab renders correctly alongside existing GPU and HuggingFace tabs
- All internal links resolve
- Configuration values are aligned with the existing e2e tests in
  test/e2e/predictor/test_huggingface_vllm_cpu.py

Signed-off-by: Marco Gonzalez <margonza@redhat.com>