### PR TITLE
fix: support dark theme for diagrams and inline config cards

### DIFF
--- a/docs/model-serving/generative-inference/llmisvc/llmisvc-config-composition.md
+++ b/docs/model-serving/generative-inference/llmisvc/llmisvc-config-composition.md
@@ -4,10 +4,10 @@ sidebar_position: 4
 title: "LLMInferenceService Config Composition"
 ---
 
-export const W = ({children}) => <span style={{color: '#1565c0'}}>{children}</span>;
-export const B = ({children}) => <span style={{color: '#e65100'}}>{children}</span>;
-export const S = ({children}) => <span style={{color: '#2e7d32'}}>{children}</span>;
-export const Note = ({children}) => <span style={{color: '#999', fontSize: '0.75rem'}}>{children}</span>;
+export const W = ({children}) => <span style={{color: 'var(--cfg-text-wellknown)'}}>{children}</span>;
+export const B = ({children}) => <span style={{color: 'var(--cfg-text-baseref)'}}>{children}</span>;
+export const S = ({children}) => <span style={{color: 'var(--cfg-text-spec)'}}>{children}</span>;
+export const Note = ({children}) => <span style={{color: 'var(--cfg-text-note)', fontSize: '0.75rem'}}>{children}</span>;
 
 # LLMInferenceService Config Composition
 
@@ -89,61 +89,61 @@ The sources that get merged (well-known configs are auto-injected, baseRef is re
 <div style={{display: 'flex', gap: '0.5rem', flexWrap: 'wrap', fontSize: '0.8rem', lineHeight: '1.4', marginBottom: '0.5rem'}}>
 
 <div style={{flex: '1 1 180px', minWidth: '180px'}}>
-<div style={{background: '#e3f2fd', padding: '0.4rem 0.6rem', borderRadius: '6px 6px 0 0', fontWeight: 600, fontSize: '0.75rem', borderBottom: '2px solid #90caf9'}}><a href="https://github.com/kserve/kserve/blob/master/config/llmisvcconfig/config-llm-template.yaml" style={{color: 'inherit', textDecoration: 'none', borderBottom: '1px dashed #90caf9'}}>kserve-config-llm-template</a></div>
-<pre style={{margin: 0, padding: '0.6rem', borderRadius: '0 0 6px 6px', border: '1px solid #e3f2fd', background: '#f5f9ff', fontSize: '0.8rem', lineHeight: '1.4'}}>
+<div style={{background: 'var(--cfg-blue-header)', padding: '0.4rem 0.6rem', borderRadius: '6px 6px 0 0', fontWeight: 600, fontSize: '0.75rem', borderBottom: '2px solid var(--cfg-blue-border)'}}><a href="https://github.com/kserve/kserve/blob/master/config/llmisvcconfig/config-llm-template.yaml" style={{color: 'inherit', textDecoration: 'none', borderBottom: '1px dashed var(--cfg-blue-border)'}}>kserve-config-llm-template</a></div>
+<pre style={{margin: 0, padding: '0.6rem', borderRadius: '0 0 6px 6px', border: '1px solid var(--cfg-blue-header)', background: 'var(--cfg-blue-body)', fontSize: '0.8rem', lineHeight: '1.4'}}>
 {"template:\n  containers:\n    - name: main\n      image: llm-d-cuda:v0.6.0\n      ports:\n        - containerPort: 8000\n      livenessProbe: [...]\n      readinessProbe: [...]\n      startupProbe: [...]\n      securityContext: [...]\n  volumes: [...]"}
 </pre>
 </div>
 
-<div style={{alignSelf: 'center', fontSize: '1.2rem', fontWeight: 700, color: '#999', padding: '0 0.15rem'}}>+</div>
+<div style={{alignSelf: 'center', fontSize: '1.2rem', fontWeight: 700, color: 'var(--cfg-separator)', padding: '0 0.15rem'}}>+</div>
 
 <div style={{flex: '1 1 180px', minWidth: '180px'}}>
-<div style={{background: '#e3f2fd', padding: '0.4rem 0.6rem', borderRadius: '6px 6px 0 0', fontWeight: 600, fontSize: '0.75rem', borderBottom: '2px solid #90caf9'}}><a href="https://github.com/kserve/kserve/blob/master/config/llmisvcconfig/config-llm-scheduler.yaml" style={{color: 'inherit', textDecoration: 'none', borderBottom: '1px dashed #90caf9'}}>kserve-config-llm-scheduler</a></div>
-<pre style={{margin: 0, padding: '0.6rem', borderRadius: '0 0 6px 6px', border: '1px solid #e3f2fd', background: '#f5f9ff', fontSize: '0.8rem', lineHeight: '1.4'}}>
+<div style={{background: 'var(--cfg-blue-header)', padding: '0.4rem 0.6rem', borderRadius: '6px 6px 0 0', fontWeight: 600, fontSize: '0.75rem', borderBottom: '2px solid var(--cfg-blue-border)'}}><a href="https://github.com/kserve/kserve/blob/master/config/llmisvcconfig/config-llm-scheduler.yaml" style={{color: 'inherit', textDecoration: 'none', borderBottom: '1px dashed var(--cfg-blue-border)'}}>kserve-config-llm-scheduler</a></div>
+<pre style={{margin: 0, padding: '0.6rem', borderRadius: '0 0 6px 6px', border: '1px solid var(--cfg-blue-header)', background: 'var(--cfg-blue-body)', fontSize: '0.8rem', lineHeight: '1.4'}}>
 {"router:\n  scheduler:\n    pool:\n      spec:\n        selector: [...]\n        targetPort: 8000\n    template:\n      containers:\n        - name: epp\n          image: llm-d-inference-scheduler\n          ports: [9002]\n        - name: tokenizer\n          image: llm-d-uds-tokenizer\n          ports: [8082]"}
 </pre>
 </div>
 
-<div style={{alignSelf: 'center', fontSize: '1.2rem', fontWeight: 700, color: '#999', padding: '0 0.15rem'}}>+</div>
+<div style={{alignSelf: 'center', fontSize: '1.2rem', fontWeight: 700, color: 'var(--cfg-separator)', padding: '0 0.15rem'}}>+</div>
 
 <div style={{flex: '1 1 180px', minWidth: '180px'}}>
-<div style={{background: '#e3f2fd', padding: '0.4rem 0.6rem', borderRadius: '6px 6px 0 0', fontWeight: 600, fontSize: '0.75rem', borderBottom: '2px solid #90caf9'}}><a href="https://github.com/kserve/kserve/blob/master/config/llmisvcconfig/config-llm-router-route.yaml" style={{color: 'inherit', textDecoration: 'none', borderBottom: '1px dashed #90caf9'}}>kserve-config-llm-router-route</a></div>
-<pre style={{margin: 0, padding: '0.6rem', borderRadius: '0 0 6px 6px', border: '1px solid #e3f2fd', background: '#f5f9ff', fontSize: '0.8rem', lineHeight: '1.4'}}>
+<div style={{background: 'var(--cfg-blue-header)', padding: '0.4rem 0.6rem', borderRadius: '6px 6px 0 0', fontWeight: 600, fontSize: '0.75rem', borderBottom: '2px solid var(--cfg-blue-border)'}}><a href="https://github.com/kserve/kserve/blob/master/config/llmisvcconfig/config-llm-router-route.yaml" style={{color: 'inherit', textDecoration: 'none', borderBottom: '1px dashed var(--cfg-blue-border)'}}>kserve-config-llm-router-route</a></div>
+<pre style={{margin: 0, padding: '0.6rem', borderRadius: '0 0 6px 6px', border: '1px solid var(--cfg-blue-header)', background: 'var(--cfg-blue-body)', fontSize: '0.8rem', lineHeight: '1.4'}}>
 {"router:\n  route:\n    http:\n      spec:\n        parentRefs:  # from KServe ingress config\n          - kind: Gateway\n        rules: [...]  # 8 rules total\n          # path + model-header per endpoint\n          # URLRewrite filters\n          # catch-all -> Service"}
 </pre>
 </div>
 
 </div>
 
-<div style={{textAlign: 'center', fontSize: '1.5rem', fontWeight: 700, color: '#999', padding: '0.25rem 0'}}>+</div>
+<div style={{textAlign: 'center', fontSize: '1.5rem', fontWeight: 700, color: 'var(--cfg-separator)', padding: '0.25rem 0'}}>+</div>
 
 <div style={{display: 'flex', gap: '0.5rem', flexWrap: 'wrap', fontSize: '0.8rem', lineHeight: '1.4'}}>
 
 <div style={{flex: '1 1 250px', minWidth: '250px'}}>
-<div style={{background: '#fff3e0', padding: '0.4rem 0.6rem', borderRadius: '6px 6px 0 0', fontWeight: 600, fontSize: '0.75rem', borderBottom: '2px solid #ffcc80'}}>baseRef: my-gpu-profile</div>
-<pre style={{margin: 0, padding: '0.6rem', borderRadius: '0 0 6px 6px', border: '1px solid #fff3e0', background: '#fffbf5', fontSize: '0.8rem', lineHeight: '1.4'}}>
+<div style={{background: 'var(--cfg-orange-header)', padding: '0.4rem 0.6rem', borderRadius: '6px 6px 0 0', fontWeight: 600, fontSize: '0.75rem', borderBottom: '2px solid var(--cfg-orange-border)'}}>baseRef: my-gpu-profile</div>
+<pre style={{margin: 0, padding: '0.6rem', borderRadius: '0 0 6px 6px', border: '1px solid var(--cfg-orange-header)', background: 'var(--cfg-orange-body)', fontSize: '0.8rem', lineHeight: '1.4'}}>
 {"replicas: 2\ntemplate:\n  nodeSelector:\n    nvidia.com/gpu.product: NVIDIA-A100-PCIE-40G\n  containers:\n    - name: main\n      resources:\n        requests:\n          nvidia.com/gpu: \"4\"\n          cpu: \"8\"\n          memory: 64Gi\n        limits:\n          nvidia.com/gpu: \"4\"\n          cpu: \"16\"\n          memory: 128Gi"}
 </pre>
 </div>
 
-<div style={{alignSelf: 'center', fontSize: '1.5rem', fontWeight: 700, color: '#999', padding: '0 0.5rem'}}>+</div>
+<div style={{alignSelf: 'center', fontSize: '1.5rem', fontWeight: 700, color: 'var(--cfg-separator)', padding: '0 0.5rem'}}>+</div>
 
 <div style={{flex: '1 1 250px', minWidth: '250px'}}>
-<div style={{background: '#e8f5e9', padding: '0.4rem 0.6rem', borderRadius: '6px 6px 0 0', fontWeight: 600, fontSize: '0.75rem', borderBottom: '2px solid #a5d6a7'}}>LLMInferenceService spec</div>
-<pre style={{margin: 0, padding: '0.6rem', borderRadius: '0 0 6px 6px', border: '1px solid #e8f5e9', background: '#f5fdf5', fontSize: '0.8rem', lineHeight: '1.4'}}>
+<div style={{background: 'var(--cfg-green-header)', padding: '0.4rem 0.6rem', borderRadius: '6px 6px 0 0', fontWeight: 600, fontSize: '0.75rem', borderBottom: '2px solid var(--cfg-green-border)'}}>LLMInferenceService spec</div>
+<pre style={{margin: 0, padding: '0.6rem', borderRadius: '0 0 6px 6px', border: '1px solid var(--cfg-green-header)', background: 'var(--cfg-green-body)', fontSize: '0.8rem', lineHeight: '1.4'}}>
 {"model:\n  uri: hf://meta-llama/Llama-3.1-8B-Instruct\n  name: meta-llama/Llama-3.1-8B-Instruct\nreplicas: 3\nrouter:\n  route: {}\n  scheduler: {}"}
 </pre>
 </div>
 
 </div>
 
-<div style={{textAlign: 'center', fontSize: '1.5rem', fontWeight: 700, color: '#999', padding: '0.5rem 0'}}>=</div>
+<div style={{textAlign: 'center', fontSize: '1.5rem', fontWeight: 700, color: 'var(--cfg-separator)', padding: '0.5rem 0'}}>=</div>
 
 **Effective merged result**:
 
-<div style={{border: '2px solid #e0e0e0', borderRadius: '8px', overflow: 'hidden'}}>
-<div style={{background: '#fafafa', padding: '0.5rem 0.75rem', fontWeight: 600, borderBottom: '1px solid #e0e0e0'}}>Effective merged configuration</div>
-<pre style={{margin: 0, padding: '0.75rem', fontSize: '0.82rem', lineHeight: '1.6', background: '#fff'}}>
+<div style={{border: '2px solid var(--cfg-gray-border)', borderRadius: '8px', overflow: 'hidden'}}>
+<div style={{background: 'var(--cfg-gray-header)', padding: '0.5rem 0.75rem', fontWeight: 600, borderBottom: '1px solid var(--cfg-gray-border)'}}>Effective merged configuration</div>
+<pre style={{margin: 0, padding: '0.75rem', fontSize: '0.82rem', lineHeight: '1.6', background: 'var(--cfg-gray-body)'}}>
 <S>{"model:\n"}</S>
 <S>{"  uri: hf://meta-llama/Llama-3.1-8B-Instruct\n"}</S>
 <S>{"  name: meta-llama/Llama-3.1-8B-Instruct\n"}</S>
@@ -210,7 +210,7 @@ The sources that get merged (well-known configs are auto-injected, baseRef is re
 <W>{"        parentRefs:  # from KServe ingress config\n          - kind: Gateway\n"}</W>
 <W>{"        rules: [...]  # 8 rules: path + model-header per endpoint, catch-all"}</W>
 </pre>
-<div style={{background: '#fafafa', padding: '0.5rem 0.75rem', borderTop: '1px solid #e0e0e0', fontSize: '0.78rem'}}>
+<div style={{background: 'var(--cfg-gray-header)', padding: '0.5rem 0.75rem', borderTop: '1px solid var(--cfg-gray-border)', fontSize: '0.78rem'}}>
   <W>{'█'}</W> Well-known config &nbsp;&nbsp;
   <B>{'█'}</B> User baseRef &nbsp;&nbsp;
   <S>{'█'}</S> LLMInferenceService spec

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -38,6 +38,25 @@
   --custom-required-badge-bg: rgba(75, 129, 230, 0.12);
   --custom-required-badge-border: #588be8;
   --custom-required-badge-text: #3371e3;
+
+  /* Config composition diagram colors */
+  --cfg-blue-header: #e3f2fd;
+  --cfg-blue-body: #f5f9ff;
+  --cfg-blue-border: #90caf9;
+  --cfg-orange-header: #fff3e0;
+  --cfg-orange-body: #fffbf5;
+  --cfg-orange-border: #ffcc80;
+  --cfg-green-header: #e8f5e9;
+  --cfg-green-body: #f5fdf5;
+  --cfg-green-border: #a5d6a7;
+  --cfg-gray-header: #fafafa;
+  --cfg-gray-body: #fff;
+  --cfg-gray-border: #e0e0e0;
+  --cfg-separator: #999;
+  --cfg-text-wellknown: #1565c0;
+  --cfg-text-baseref: #e65100;
+  --cfg-text-spec: #2e7d32;
+  --cfg-text-note: #999;
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */
@@ -56,6 +75,25 @@
   --kserve-gray: #444444;
   --kserve-gray-dark: #aaaaaa;
   --kserve-highlight: #61dafb;
+
+  /* Config composition diagram colors - dark mode */
+  --cfg-blue-header: #1a2744;
+  --cfg-blue-body: #151d2b;
+  --cfg-blue-border: #3b6098;
+  --cfg-orange-header: #3d2a10;
+  --cfg-orange-body: #1f1a12;
+  --cfg-orange-border: #8b6914;
+  --cfg-green-header: #1a3320;
+  --cfg-green-body: #141f16;
+  --cfg-green-border: #4a8a50;
+  --cfg-gray-header: #2d2d2d;
+  --cfg-gray-body: #1e1e1e;
+  --cfg-gray-border: #444;
+  --cfg-separator: #777;
+  --cfg-text-wellknown: #64b5f6;
+  --cfg-text-baseref: #ffb74d;
+  --cfg-text-spec: #81c784;
+  --cfg-text-note: #777;
 }
 
 /* Global styles */
@@ -666,4 +704,10 @@ footer.footer .footer__col {
     grid-template-columns: repeat(2, 1fr);
     gap: 1.5rem;
   }
+}
+
+/* Invert diagrams.net SVGs in dark mode */
+[data-theme="dark"] article svg[style*="background-color: rgb(255, 255, 255)"] {
+  filter: invert(0.88) hue-rotate(180deg);
+  border-radius: 8px;
 }


### PR DESCRIPTION
## What

Fixes dark theme rendering for all diagrams across the docs site. The config composition page had inline-styled cards with hardcoded light-mode colors that rendered as bright white boxes on dark backgrounds. The node-scheduling SVGs (exported from diagrams.net) had the same problem - white backgrounds with black text, completely unreadable in dark mode.

## Why

Dark theme was effectively broken for any page with visual diagrams - the content was there but you couldn't read it.

<img width="1228" height="479" alt="image" src="https://github.com/user-attachments/assets/3a338c50-b2bf-4652-92df-673c572e02a5" />

<img width="1228" height="479" alt="image" src="https://github.com/user-attachments/assets/23cf5759-a238-4192-a076-7115ba1ee503" />

<img width="1559" height="1053" alt="image" src="https://github.com/user-attachments/assets/e49489ec-6be3-489e-b36d-34fc9ab50cfc" />

<img width="1559" height="1053" alt="image" src="https://github.com/user-attachments/assets/005f3833-2618-4390-8b1f-1c58997b82b0" />

## How it works now

Config composition cards use CSS custom properties instead of hardcoded hex values, with a full dark-mode palette that preserves the blue/orange/green color coding while keeping contrast readable. The diagrams.net SVGs get a CSS `filter: invert() hue-rotate()` treatment in dark mode that flips them cleanly without distorting the original color relationships.

Light mode is visually unchanged.