### PR TITLE
Fix admonitions that don't render: '::: warning' spacing and unsupported ':::success' type

### DIFF
--- a/docs/admin-guide/kubernetes-deployment-llmisvc.md
+++ b/docs/admin-guide/kubernetes-deployment-llmisvc.md
@@ -141,7 +141,7 @@ Install only LLMInferenceService CRDs and controller using helm:
 LLMISVC=true infra/manage.kserve-helm.sh
 ```
 
-:::success
+:::tip
 This installs only the LLMInferenceService components. InferenceService is not included.
 :::
 

--- a/docs/getting-started/predictive-first-isvc.md
+++ b/docs/getting-started/predictive-first-isvc.md
@@ -27,7 +27,7 @@ kubectl create namespace kserve-test
 ### 2. Create an `InferenceService`
 Create an InferenceService to deploy the Iris model. This model will be served using KServe's Scikit-learn runtime for optimized performance.
 
-::: warning
+:::warning
 Do not deploy `InferenceServices` in control plane namespaces (i.e. namespaces with `control-plane` label). The webhook is configured in a way to skip these namespaces to avoid any privilege escalations. Deploying InferenceServices to these namespaces will result in the storage initializer not being injected into the pod, causing the pod to fail with the error `No such file or directory: '/mnt/models'`.
 :::
 

--- a/versioned_docs/version-0.16/admin-guide/kubernetes-deployment-llmisvc.md
+++ b/versioned_docs/version-0.16/admin-guide/kubernetes-deployment-llmisvc.md
@@ -141,7 +141,7 @@ Install only LLMInferenceService CRDs and controller using helm:
 LLMISVC=true infra/manage.kserve-helm.sh
 ```
 
-:::success
+:::tip
 This installs only the LLMInferenceService components. InferenceService is not included.
 :::
 

--- a/versioned_docs/version-0.16/getting-started/predictive-first-isvc.md
+++ b/versioned_docs/version-0.16/getting-started/predictive-first-isvc.md
@@ -27,7 +27,7 @@ kubectl create namespace kserve-test
 ### 2. Create an `InferenceService`
 Create an InferenceService to deploy the Iris model. This model will be served using KServe's Scikit-learn runtime for optimized performance.
 
-::: warning
+:::warning
 Do not deploy `InferenceServices` in control plane namespaces (i.e. namespaces with `control-plane` label). The webhook is configured in a way to skip these namespaces to avoid any privilege escalations. Deploying InferenceServices to these namespaces will result in the storage initializer not being injected into the pod, causing the pod to fail with the error `No such file or directory: '/mnt/models'`.
 :::
 

--- a/versioned_docs/version-0.16/getting-started/quickstart-guide.md
+++ b/versioned_docs/version-0.16/getting-started/quickstart-guide.md
@@ -188,7 +188,7 @@ curl -s "https://raw.githubusercontent.com/kserve/kserve/master/hack/setup/quick
 9. ✅ Gateway
 10. ✅ LLMInferenceService CRDs and Controller
 
-:::success
+:::tip
 This installs only LLMInferenceService components. KServe (Standard) is not included.
 :::
 

--- a/versioned_docs/version-0.17/admin-guide/kubernetes-deployment-llmisvc.md
+++ b/versioned_docs/version-0.17/admin-guide/kubernetes-deployment-llmisvc.md
@@ -141,7 +141,7 @@ Install only LLMInferenceService CRDs and controller using helm:
 LLMISVC=true infra/manage.kserve-helm.sh
 ```
 
-:::success
+:::tip
 This installs only the LLMInferenceService components. InferenceService is not included.
 :::
 

--- a/versioned_docs/version-0.17/getting-started/predictive-first-isvc.md
+++ b/versioned_docs/version-0.17/getting-started/predictive-first-isvc.md
@@ -27,7 +27,7 @@ kubectl create namespace kserve-test
 ### 2. Create an `InferenceService`
 Create an InferenceService to deploy the Iris model. This model will be served using KServe's Scikit-learn runtime for optimized performance.
 
-::: warning
+:::warning
 Do not deploy `InferenceServices` in control plane namespaces (i.e. namespaces with `control-plane` label). The webhook is configured in a way to skip these namespaces to avoid any privilege escalations. Deploying InferenceServices to these namespaces will result in the storage initializer not being injected into the pod, causing the pod to fail with the error `No such file or directory: '/mnt/models'`.
 :::
 

--- a/versioned_docs/version-0.18/admin-guide/kubernetes-deployment-llmisvc.md
+++ b/versioned_docs/version-0.18/admin-guide/kubernetes-deployment-llmisvc.md
@@ -141,7 +141,7 @@ Install only LLMInferenceService CRDs and controller using helm:
 LLMISVC=true infra/manage.kserve-helm.sh
 ```
 
-:::success
+:::tip
 This installs only the LLMInferenceService components. InferenceService is not included.
 :::
 

--- a/versioned_docs/version-0.18/getting-started/predictive-first-isvc.md
+++ b/versioned_docs/version-0.18/getting-started/predictive-first-isvc.md
@@ -27,7 +27,7 @@ kubectl create namespace kserve-test
 ### 2. Create an `InferenceService`
 Create an InferenceService to deploy the Iris model. This model will be served using KServe's Scikit-learn runtime for optimized performance.
 
-::: warning
+:::warning
 Do not deploy `InferenceServices` in control plane namespaces (i.e. namespaces with `control-plane` label). The webhook is configured in a way to skip these namespaces to avoid any privilege escalations. Deploying InferenceServices to these namespaces will result in the storage initializer not being injected into the pod, causing the pod to fail with the error `No such file or directory: '/mnt/models'`.
 :::
 


### PR DESCRIPTION
Fixes two admonition syntax issues that silently break rendering on the website (no open issue; found by scanning the docs for malformed directives).

## Proposed Changes

- Fix `::: warning` (space after colons) → `:::warning` in `getting-started/predictive-first-isvc.md` (current docs + versions 0.16–0.18). The directive parser requires the name to immediately follow the colons, so the page currently shows the literal text `::: warning` … `:::` instead of a warning callout — hiding the "do not deploy InferenceServices in control-plane namespaces" warning:

  ```diff
  -::: warning
  +:::warning
   Do not deploy `InferenceServices` in control plane namespaces ...
   :::
  ```

- Replace unsupported `:::success` with `:::tip` in `admin-guide/kubernetes-deployment-llmisvc.md` (current + 0.16–0.18) and `version-0.16/getting-started/quickstart-guide.md`, per the contribution guidelines in the README ("Use tip admonition instead of success admonition"). `success` is not a registered Docusaurus admonition type and no custom keywords are configured, so these blocks render without a callout box and produce "unused directives" build warnings:

  ```diff
  -:::success
  +:::tip
   This installs only the LLMInferenceService components. InferenceService is not included.
   :::
  ```