### PR TITLE
docs: fix broken KServe governance link in contribution guide

### DIFF
--- a/docs/developer-guide/contribution.md
+++ b/docs/developer-guide/contribution.md
@@ -465,7 +465,7 @@ If you're interested in becoming a KServe member:
 1. **Contribute regularly**: Show sustained, high-quality contributions
 2. **Help others**: Answer questions in the community channels
 3. **Review PRs**: Help review other contributors' pull requests
-4. **Follow the process**: Read the [KServe governance docs](https://github.com/kserve/community/blob/main/GOVERNANCE.md) for full details
+4. **Follow the process**: Read the [KServe governance docs](https://github.com/kserve/community) for full details
 
 ### Contributing Organizations
 

--- a/versioned_docs/version-0.16/developer-guide/contribution.md
+++ b/versioned_docs/version-0.16/developer-guide/contribution.md
@@ -465,7 +465,7 @@ If you're interested in becoming a KServe member:
 1. **Contribute regularly**: Show sustained, high-quality contributions
 2. **Help others**: Answer questions in the community channels
 3. **Review PRs**: Help review other contributors' pull requests
-4. **Follow the process**: Read the [KServe governance docs](https://github.com/kserve/community/blob/main/GOVERNANCE.md) for full details
+4. **Follow the process**: Read the [KServe governance docs](https://github.com/kserve/community) for full details
 
 ### Contributing Organizations
 

--- a/versioned_docs/version-0.17/developer-guide/contribution.md
+++ b/versioned_docs/version-0.17/developer-guide/contribution.md
@@ -465,7 +465,7 @@ If you're interested in becoming a KServe member:
 1. **Contribute regularly**: Show sustained, high-quality contributions
 2. **Help others**: Answer questions in the community channels
 3. **Review PRs**: Help review other contributors' pull requests
-4. **Follow the process**: Read the [KServe governance docs](https://github.com/kserve/community/blob/main/GOVERNANCE.md) for full details
+4. **Follow the process**: Read the [KServe governance docs](https://github.com/kserve/community) for full details
 
 ### Contributing Organizations
 

--- a/versioned_docs/version-0.18/developer-guide/contribution.md
+++ b/versioned_docs/version-0.18/developer-guide/contribution.md
@@ -465,7 +465,7 @@ If you're interested in becoming a KServe member:
 1. **Contribute regularly**: Show sustained, high-quality contributions
 2. **Help others**: Answer questions in the community channels
 3. **Review PRs**: Help review other contributors' pull requests
-4. **Follow the process**: Read the [KServe governance docs](https://github.com/kserve/community/blob/main/GOVERNANCE.md) for full details
+4. **Follow the process**: Read the [KServe governance docs](https://github.com/kserve/community) for full details
 
 ### Contributing Organizations
 


### PR DESCRIPTION
The contribution guide links to `https://github.com/kserve/community/blob/main/GOVERNANCE.md`, which has never existed, so the link 404s. Governance documentation (ROLES.md, membership.md, TECHNICAL-STEERING-COMMITTEE.md) lives in the kserve/community repository, so this points the "KServe governance docs" link at the repository root instead.

Fixed in the current docs and the version-0.16/0.17/0.18 versioned snapshots, which all contain the same dead link.

Fixes kserve/kserve#5765
