### PR TITLE
docs(llmisvc): add canary rollout guide for traffic splitting

### DIFF
--- a/docs/model-serving/generative-inference/llmisvc/canary-rollout-observability.md
+++ b/docs/model-serving/generative-inference/llmisvc/canary-rollout-observability.md
@@ -1,0 +1,278 @@
+---
+sidebar_label: "Canary Rollout Observability"
+sidebar_position: 10
+title: "Observability for Canary Rollouts"
+description: "Per-version metrics, tracing, and comparison queries for validating canary deployments"
+---
+
+import CanaryObservabilitySvg from './imgs/canary_observability_channels.svg';
+
+You have two versions of your model running side by side and traffic is splitting between them. But how do you actually know if the canary is performing better, worse, or about the same as production?
+
+This guide walks through setting up per-version observability for canary rollouts - from Prometheus scraping to PromQL queries that compare versions during a rollout.
+
+## Prerequisites
+
+- Two LLMInferenceServices in a routing group (e.g., `my-model-v1` at weight 9, `my-model-v2` at weight 1)
+- Prometheus (kube-prometheus-stack or OpenShift monitoring)
+- `kubectl` access
+
+## What You Get Out of the Box
+
+<CanaryObservabilitySvg />
+
+Each version is a separate LLMInferenceService with its own pods, InferencePool, and scheduler. Metrics naturally carry version identity - you just need the right labels to filter by version.
+
+| Channel | What it tells you | Per-version? | Setup needed |
+|---|---|---|---|
+| vLLM metrics | TTFT, throughput, error rate, KV cache, queue depth | Yes - via PodMonitor relabeling adds `llm_isvc_name` | PodMonitor |
+| EPP scheduler metrics | Pool-level KV cache, queue size, ready endpoints | Yes - via job label = EPP service name | ServiceMonitor |
+| Distributed traces | Per-request latency breakdown, version attribution | Yes - `llmisvc.name` resource attribute | [`spec.tracing`](#distributed-tracing) on LLMISVC |
+
+---
+
+## Setting Up Prometheus Scraping
+
+### vLLM Metrics (PodMonitor)
+
+vLLM exposes metrics on port 8000 with a `model_name` label - but that label is the same for both versions (they serve the same model). To tell versions apart, you need a PodMonitor that copies the pod's `app.kubernetes.io/name` label into a `llm_isvc_name` metric label.
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: llmisvc-vllm
+  labels:
+    release: prometheus
+spec:
+  selector:
+    matchLabels:
+      kserve.io/component: workload
+  podMetricsEndpoints:
+    - portNumber: 8000
+      path: /metrics
+      interval: 10s
+      params:
+        format:
+          - prometheus
+      relabelings:
+        - sourceLabels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
+          targetLabel: llm_isvc_name
+```
+
+The `relabelings` block is the key part. Without it, you get vLLM metrics but can't distinguish which version produced them.
+
+### EPP Scheduler Metrics (ServiceMonitor)
+
+The EPP (llm-d-router) exposes metrics on port 9090. Authentication may be enabled by default depending on the version - if so, the scraping ServiceAccount needs `get` access to the `/metrics` nonResourceURL.
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: llmisvc-epp
+  labels:
+    release: prometheus
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: llminferenceservice-router-scheduler
+  endpoints:
+    - port: metrics
+      interval: 10s
+```
+
+:::note
+If EPP has `--metrics-endpoint-auth=true` (the default in some versions), you'll need a ServiceAccount with a token Secret and a ClusterRole granting `get` on `/metrics`. The ServiceMonitor then references the token via `authorization.credentials`. If you're using kube-prometheus-stack, its Prometheus ServiceAccount may already have the required permissions.
+:::
+
+---
+
+## Verifying Metrics Are Flowing
+
+Before building dashboards, make sure Prometheus is scraping what you expect.
+
+```bash
+kubectl port-forward -n monitoring svc/prometheus-operated 9090:9090 &
+```
+
+**vLLM metrics** (requires PodMonitor):
+
+```promql
+vllm:request_success_total{llm_isvc_name=~"my-model-.*"}
+```
+
+Look for distinct `llm_isvc_name` values. If the label is missing, the PodMonitor relabeling isn't working.
+
+**EPP metrics** (requires ServiceMonitor):
+
+```promql
+inference_pool_ready_pods
+```
+
+If empty, check `kubectl get servicemonitor` and the Prometheus targets page for scrape errors.
+
+---
+
+## Comparing Versions During a Canary Rollout
+
+### Traffic Split Verification
+
+Is the actual distribution matching what you configured? Compare per-version request rates:
+
+```promql
+sum by (llm_isvc_name) (
+  rate(vllm:request_success_total[5m])
+)
+```
+
+### Time to First Token (TTFT)
+
+The metric users feel most. Compare P95:
+
+```promql
+histogram_quantile(0.95,
+  sum by (le, llm_isvc_name) (
+    rate(vllm:time_to_first_token_seconds_bucket[5m])
+  )
+)
+```
+
+If the canary's P95 TTFT is significantly higher, that's a signal to stop the rollout.
+
+### E2E Request Latency
+
+Full request latency including queue time:
+
+```promql
+histogram_quantile(0.95,
+  sum by (le, llm_isvc_name) (
+    rate(vllm:e2e_request_latency_seconds_bucket[5m])
+  )
+)
+```
+
+### Generation Throughput
+
+Tokens per second per version:
+
+```promql
+sum by (llm_isvc_name) (
+  rate(vllm:generation_tokens_total[5m])
+)
+```
+
+### Error Rate
+
+Per-version HTTP error rate from the FastAPI instrumentator:
+
+```promql
+sum by (llm_isvc_name) (
+  rate(http_requests_total{status!="2xx"}[5m])
+)
+/
+sum by (llm_isvc_name) (
+  rate(http_requests_total[5m])
+)
+```
+
+### KV Cache Utilization
+
+Per-version cache pressure:
+
+```promql
+avg by (llm_isvc_name) (
+  vllm:kv_cache_usage_perc
+) * 100
+```
+
+### Queue Depth
+
+Per-version pending requests:
+
+```promql
+sum by (llm_isvc_name) (
+  vllm:num_requests_waiting
+)
+```
+
+### Queue Time vs Prefill/Decode Time
+
+Tells you whether high latency is a capacity issue (need more pods) or an engine issue (model is slow):
+
+```promql
+# Queue time P95
+histogram_quantile(0.95,
+  sum by (le, llm_isvc_name) (
+    rate(vllm:request_queue_time_seconds_bucket[5m])
+  )
+)
+```
+
+```promql
+# Prefill time P95
+histogram_quantile(0.95,
+  sum by (le, llm_isvc_name) (
+    rate(vllm:request_prefill_time_seconds_bucket[5m])
+  )
+)
+```
+
+```promql
+# Decode time P95
+histogram_quantile(0.95,
+  sum by (le, llm_isvc_name) (
+    rate(vllm:request_decode_time_seconds_bucket[5m])
+  )
+)
+```
+
+Queue time >> prefill+decode time = need more replicas. Prefill or decode time high but queue time low = engine bottleneck.
+
+---
+
+## Distributed Tracing
+
+LLMInferenceService has a declarative tracing API - add `spec.tracing` to enable OpenTelemetry instrumentation without manually wiring env vars. The same tracing config applies to both the inference server and the scheduler.
+
+```yaml
+apiVersion: serving.kserve.io/v1alpha2
+kind: LLMInferenceService
+metadata:
+  name: my-model-v1
+spec:
+  tracing:
+    exporterEndpoint: "http://otel-collector.kserve.svc:4317"
+    sampler: "always_on"
+  # ...
+```
+
+The controller auto-injects OTEL environment variables into both the vLLM container and the EPP scheduler with `llmisvc.name` as a resource attribute. Each version gets a distinct trace identity, so you can filter and compare per-request latency in Jaeger or Tempo.
+
+### Tracing configuration
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `exporterEndpoint` | `http://otel-collector:4317` | OTLP gRPC endpoint for trace export |
+| `exporter` | `otlp` | Trace exporter type |
+| `sampler` | `parentbased_traceidratio` | Sampling strategy - see below |
+| `samplerArg` | `"0.05"` | Argument for ratio-based samplers (e.g. `"0.05"` for 5%) |
+
+Defaults are provided by the well-known config during config merge. When `spec.tracing` is omitted entirely, no tracing instrumentation is injected.
+
+**Samplers:**
+
+| Sampler | When to use |
+|---------|-------------|
+| `always_on` | Canary validation - capture every request. High trace volume. |
+| `parentbased_traceidratio` | Production steady state - sample a fraction of requests (set `samplerArg` to the rate) |
+| `parentbased_always_off` | Disable tracing while keeping the config in place |
+
+:::tip
+For canary validation, set `sampler: "always_on"` temporarily on both versions. Switch back to `parentbased_traceidratio` for steady-state production.
+:::
+
+### Kubernetes resource attributes
+
+When tracing is enabled, the controller automatically injects pod name, node name, and namespace as OTEL resource attributes via the downward API. No user configuration needed.
+

--- a/docs/model-serving/generative-inference/llmisvc/canary-rollout.md
+++ b/docs/model-serving/generative-inference/llmisvc/canary-rollout.md
@@ -1,0 +1,310 @@
+---
+sidebar_label: "Canary Rollout"
+sidebar_position: 9
+title: "Canary Rollout for LLMInferenceService"
+description: "Progressive traffic shifting for safe model upgrades, runtime changes, and configuration updates"
+---
+
+import CanaryArchitectureSvg from './imgs/canary_routing_architecture.svg';
+import CanaryProgressionSvg from './imgs/canary_traffic_progression.svg';
+
+# Canary Rollout for LLMInferenceService
+
+Runtime upgrades and model rotations on LLM inference workloads are all-or-nothing - a bad image or a model regression takes down the whole endpoint with no quick way back.
+
+Canary rollout lets you run two versions side by side, shift traffic between them, and roll back instantly.
+
+## How It Works
+
+Each LLMInferenceService that participates in a canary rollout declares two fields in `spec.router.route`:
+
+- **`group`** - a string identifying which versions belong together
+- **`weight`** - an integer for this version's proportional traffic share
+
+Weights are proportional, not percentages. v1 at 9 and v2 at 1 gives 90/10. v1 at 9 and v2 at 9 gives 50/50. To shift traffic, you only patch the version you're changing - no need to edit both resources.
+
+The controller discovers all group members, creates weighted `backendRef` entries in each member's HTTPRoute, and maintains group status on every member.
+
+There is no "primary" or "canary" distinction in the API - every member is symmetric. The semantics come from the weights you assign.
+
+```yaml
+spec:
+  router:
+    route:
+      group: my-model
+      weight: 9
+    scheduler: {}
+```
+
+The webhook automatically sets the label `serving.kserve.io/routing-group` on each member resource, which the controller uses for group discovery.
+
+<CanaryArchitectureSvg />
+
+Each LLMInferenceService creates and owns its own HTTPRoute. Every route carries the same weighted backendRef set for all active (non-stopped) group members. Gateway API precedence rules pick one active route - the oldest route wins when matches are identical. That active route's weighted backendRef set determines how the gateway distributes traffic.
+
+---
+
+## Rollout Lifecycle
+
+<CanaryProgressionSvg />
+
+The typical canary rollout follows these steps:
+
+1. **Deploy v2 alongside v1** with a small weight
+2. **Wait for v2 to become Ready** and start receiving traffic
+3. **Ramp v2's weight** while monitoring metrics - only patch the version you're changing, weights are proportional
+4. **Promote v2** by force-stopping v1 (frees GPU, preserves the resource for rollback)
+5. **Decommission v1** when confident
+
+At any point, roll back by lowering v2's weight or restarting v1.
+
+### Starting dark vs starting live
+
+:::warning
+Deploying a canary at `weight: 0` (a "dark deployment") may cause transient connection failures when you later increase the weight. The theory: when the weight is zero, the gateway may not warm the backend cluster. Changing to a non-zero weight then triggers both a cluster discovery (CDS) and route (RDS) update simultaneously, and the CDS update can briefly disrupt connections.
+
+The safer pattern is to deploy at `weight: 1` so the backend is warmed from the start. In a 9:1 split, this means roughly 10% of traffic goes to v2 immediately - which is actually desirable for LLM inference since it validates the full vLLM/scheduler stack handles real requests before ramping up.
+:::
+
+---
+
+## Step-by-Step Guide
+
+### Prerequisites
+
+- A running KServe installation with the LLMInferenceService controller
+- A Gateway API implementation with support for weighted `backendRef`s
+- `kubectl` configured with cluster access
+- Familiarity with [LLMInferenceService basics](./llmisvc-overview.md)
+
+### Step 1: Deploy the Production Version (v1)
+
+Start by deploying v1 with `group` and `weight` set:
+
+```yaml
+apiVersion: serving.kserve.io/v1alpha2
+kind: LLMInferenceService
+metadata:
+  name: my-model-v1
+  namespace: my-namespace
+spec:
+  model:
+    name: my-model
+    uri: hf://meta-llama/Llama-3-70B
+  baseRefs:
+    - name: model-config
+    - name: workload-config
+  router:
+    route:
+      group: my-model
+      weight: 9
+    scheduler: {}
+```
+
+```bash
+kubectl apply -f my-model-v1.yaml
+kubectl wait llmisvc my-model-v1 -n my-namespace --for=condition=Ready --timeout=300s
+```
+
+Verify the routing group label:
+
+```bash
+kubectl get llmisvc my-model-v1 -n my-namespace \
+    -o jsonpath='{.metadata.labels.serving\.kserve\.io/routing-group}'
+```
+
+:::tip[Expected Output]
+```
+my-model
+```
+:::
+
+At this point, v1 is the only group member and receives 100% of traffic.
+
+### Step 2: Deploy the Canary Version (v2)
+
+Deploy v2 with the same `group` but `weight: 1`. This gives a 9:1 split (~90% v1, ~10% v2) once v2 is Ready.
+
+:::tip
+Starting at `weight: 1` rather than `weight: 0` avoids transient connection issues that can occur when the gateway hasn't warmed the backend cluster. See [Starting dark vs starting live](#starting-dark-vs-starting-live) for details.
+:::
+
+```yaml
+apiVersion: serving.kserve.io/v1alpha2
+kind: LLMInferenceService
+metadata:
+  name: my-model-v2
+  namespace: my-namespace
+spec:
+  model:
+    name: my-model
+    uri: hf://meta-llama/Llama-3.1-70B
+  baseRefs:
+    - name: model-config-v2
+    - name: workload-config
+  router:
+    route:
+      group: my-model      # same group as v1
+      weight: 1
+    scheduler: {}
+```
+
+Note that `group` and `model.name` match v1 - that's what makes them part of the same traffic split.
+
+:::warning
+Group members must share the same model name and LoRA adapter set. Members that differ on either form independent sub-groups and get `GroupDegraded=True` with reason `MemberDivergence`.
+:::
+
+Wait for v2, then check group status:
+
+```bash
+kubectl wait llmisvc my-model-v2 -n my-namespace --for=condition=Ready --timeout=300s
+kubectl get llmisvc my-model-v1 -n my-namespace \
+    -o jsonpath='{.status.router.group}' | python3 -m json.tool
+```
+
+:::tip[Expected Output]
+```json
+{
+    "name": "my-model",
+    "members": [
+        {"name": "my-model-v1", "weight": 9},
+        {"name": "my-model-v2", "weight": 1}
+    ]
+}
+```
+:::
+
+Traffic is now splitting ~90% to v1, ~10% to v2.
+
+### Step 3: Validate the Canary
+
+Before ramping traffic, verify the canary is healthy. Compare P95 time-to-first-token between versions:
+
+```promql
+histogram_quantile(0.95,
+  sum by (le, llm_isvc_name) (
+    rate(vllm:time_to_first_token_seconds_bucket[5m])
+  )
+)
+```
+
+If the canary's TTFT is significantly higher, that's a signal to investigate before ramping.
+
+:::note
+This query requires a PodMonitor with `llm_isvc_name` relabeling. See [Observability for Canary Rollouts](./canary-rollout-observability.md) for setup instructions, traffic split verification queries, and more comparison metrics.
+:::
+
+### Step 4: Ramp Traffic
+
+If the canary looks good, ramp v2's weight to get a 50/50 split. Weights are proportional - you only need to patch the version you're changing:
+
+```bash
+kubectl patch llmisvc my-model-v2 -n my-namespace --type merge \
+    -p '{"spec":{"router":{"route":{"weight":9}}}}'
+```
+
+With v1 at 9 and v2 at 9, traffic splits evenly. No need to touch v1.
+
+The controller updates HTTPRoute backendRef weights on all group members. Traffic shifts within seconds - no pod restarts.
+
+### Step 5: Promote
+
+When confident, promote v2 to full traffic by force-stopping v1:
+
+```bash
+kubectl annotate llmisvc my-model-v1 -n my-namespace \
+    serving.kserve.io/stop=true
+```
+
+v1's pods scale to zero - GPU resources are released. All traffic flows to v2. v1 stays visible in group status with `stopped: true` and its declared weight preserved for rollback.
+
+Check the group status:
+
+```bash
+kubectl get llmisvc my-model-v2 -n my-namespace \
+    -o jsonpath='{.status.router.group}' | python3 -m json.tool
+```
+
+:::tip[Expected Output]
+```json
+{
+    "name": "my-model",
+    "members": [
+        {"name": "my-model-v1", "weight": 9, "stopped": true},
+        {"name": "my-model-v2", "weight": 9}
+    ]
+}
+```
+:::
+
+### Step 6: Rollback (if needed)
+
+At any point during the rollout, you can shift traffic back to v1. If v1 is still running, just lower v2's weight:
+
+```bash
+kubectl patch llmisvc my-model-v2 -n my-namespace --type merge \
+    -p '{"spec":{"router":{"route":{"weight":1}}}}'
+```
+
+If v1 was force-stopped, remove the annotation to restart it:
+
+```bash
+kubectl annotate llmisvc my-model-v1 -n my-namespace serving.kserve.io/stop-
+kubectl wait llmisvc my-model-v1 -n my-namespace --for=condition=Ready --timeout=300s
+```
+
+Once Ready, v1 rejoins weighted routing with its preserved weight.
+
+### Step 7: Decommission
+
+When the old version is no longer needed:
+
+```bash
+kubectl delete llmisvc my-model-v1 -n my-namespace
+```
+
+The controller removes v1's backendRef from v2's HTTPRoute and updates group status. v2 continues serving as a standalone group member.
+
+---
+
+## Direct Version Access
+
+Regardless of weights, you can reach a specific running version via its per-participant path:
+
+```bash
+# Always hits v1
+curl http://<gateway-address>/my-namespace/my-model-v1/v1/completions \
+    -H "Content-Type: application/json" \
+    -d '{"model":"my-model","prompt":"Hello","max_tokens":5}'
+
+# Always hits v2
+curl http://<gateway-address>/my-namespace/my-model-v2/v1/completions \
+    -H "Content-Type: application/json" \
+    -d '{"model":"my-model","prompt":"Hello","max_tokens":5}'
+```
+
+Direct access paths bypass weighted routing entirely. Useful for debugging, testing, or running comparison benchmarks. Force-stopped services have no HTTPRoute and are not directly reachable until restarted.
+
+## Stable Model URL (Publisher Path)
+
+For production clients that should not be aware of specific version names, use the publisher path:
+
+```
+/publishers/<namespace>/models/<model-name>/v1/completions
+```
+
+This URL is version-agnostic - requests route according to the current weight distribution. The model-routing addresses in `status.addresses` carry the publisher-qualified model name:
+
+```bash
+kubectl get llmisvc my-model-v1 -n my-namespace \
+    -o jsonpath='{.status.addresses[?(@.name=="internal-model-routing")].url}'
+```
+
+---
+
+## What's Next
+
+- [Observability for Canary Rollouts](./canary-rollout-observability.md) - metrics setup and comparison queries
+- [Configuration Reference](./llmisvc-configuration.md) - traffic splitting field details
+- [Status Reference](./llmisvc-status.md#group-conditions-traffic-splitting) - group conditions and status structure

--- a/docs/model-serving/generative-inference/llmisvc/imgs/canary_observability_channels.svg
+++ b/docs/model-serving/generative-inference/llmisvc/imgs/canary_observability_channels.svg
@@ -1,0 +1,62 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="720" height="205" viewBox="0 0 720 205">
+  <defs>
+    <filter id="shadow" x="-5%" y="-5%" width="110%" height="120%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2" result="blur"/>
+      <feOffset dx="0" dy="1" result="shifted"/>
+      <feFlood flood-color="#000" flood-opacity="0.06" result="color"/>
+      <feComposite in="color" in2="shifted" operator="in" result="shadow"/>
+      <feMerge>
+        <feMergeNode in="shadow"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5"
+            markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0,0 L10,5 L0,10z" fill="#4A7FBF"/>
+    </marker>
+  </defs>
+
+  <rect width="720" height="205" fill="#F6F8FA" rx="4"/>
+
+  <!-- Row 1: vLLM Pods -> Prometheus -->
+  <rect x="16" y="24" width="140" height="36" rx="8" fill="#fff" stroke="#4A7FBF" stroke-width="1.2" filter="url(#shadow)"/>
+  <text x="86" y="47" text-anchor="middle" font-family="Arial,Helvetica,sans-serif" font-size="12" font-weight="bold" fill="#1F2937">vLLM Pods</text>
+
+  <line x1="156" y1="42" x2="252" y2="42" stroke="#4A7FBF" stroke-width="1.4"/>
+  <rect x="252" y="32" width="92" height="20" rx="10" fill="#EDF2F7" stroke="#4A7FBF" stroke-width="0.8"/>
+  <text x="298" y="46" text-anchor="middle" font-family="'SFMono-Regular',Consolas,'Liberation Mono',Menlo,monospace" font-size="9" fill="#4A7FBF">llm_isvc_name</text>
+  <line x1="344" y1="42" x2="440" y2="42" stroke="#4A7FBF" stroke-width="1.4" marker-end="url(#arrow)"/>
+
+  <rect x="440" y="24" width="120" height="36" rx="8" fill="#fff" stroke="#6B7280" stroke-width="1.2" filter="url(#shadow)"/>
+  <text x="500" y="47" text-anchor="middle" font-family="Arial,Helvetica,sans-serif" font-size="12" font-weight="bold" fill="#1F2937">Prometheus</text>
+
+  <text x="570" y="46" text-anchor="start" font-family="Arial,Helvetica,sans-serif" font-size="10" fill="#8B949E">PodMonitor relabeling</text>
+
+  <!-- Row 2: EPP Scheduler -> Prometheus -->
+  <rect x="16" y="79" width="140" height="36" rx="8" fill="#fff" stroke="#4A7FBF" stroke-width="1.2" filter="url(#shadow)"/>
+  <text x="86" y="102" text-anchor="middle" font-family="Arial,Helvetica,sans-serif" font-size="12" font-weight="bold" fill="#1F2937">EPP Scheduler</text>
+
+  <line x1="156" y1="97" x2="278" y2="97" stroke="#4A7FBF" stroke-width="1.4"/>
+  <rect x="278" y="87" width="40" height="20" rx="10" fill="#EDF2F7" stroke="#4A7FBF" stroke-width="0.8"/>
+  <text x="298" y="101" text-anchor="middle" font-family="'SFMono-Regular',Consolas,'Liberation Mono',Menlo,monospace" font-size="9" fill="#4A7FBF">job</text>
+  <line x1="318" y1="97" x2="440" y2="97" stroke="#4A7FBF" stroke-width="1.4" marker-end="url(#arrow)"/>
+
+  <rect x="440" y="79" width="120" height="36" rx="8" fill="#fff" stroke="#6B7280" stroke-width="1.2" filter="url(#shadow)"/>
+  <text x="500" y="102" text-anchor="middle" font-family="Arial,Helvetica,sans-serif" font-size="12" font-weight="bold" fill="#1F2937">Prometheus</text>
+
+  <text x="570" y="101" text-anchor="start" font-family="Arial,Helvetica,sans-serif" font-size="10" fill="#8B949E">ServiceMonitor</text>
+
+  <!-- Row 3: vLLM (OTEL) -> Jaeger / Tempo -->
+  <rect x="16" y="134" width="140" height="36" rx="8" fill="#fff" stroke="#4A7FBF" stroke-width="1.2" filter="url(#shadow)"/>
+  <text x="86" y="157" text-anchor="middle" font-family="Arial,Helvetica,sans-serif" font-size="12" font-weight="bold" fill="#1F2937">vLLM (OTEL)</text>
+
+  <line x1="156" y1="152" x2="255" y2="152" stroke="#4A7FBF" stroke-width="1.4"/>
+  <rect x="255" y="142" width="86" height="20" rx="10" fill="#EDF2F7" stroke="#4A7FBF" stroke-width="0.8"/>
+  <text x="298" y="156" text-anchor="middle" font-family="'SFMono-Regular',Consolas,'Liberation Mono',Menlo,monospace" font-size="9" fill="#4A7FBF">llmisvc.name</text>
+  <line x1="341" y1="152" x2="440" y2="152" stroke="#4A7FBF" stroke-width="1.4" marker-end="url(#arrow)"/>
+
+  <rect x="440" y="134" width="120" height="36" rx="8" fill="#fff" stroke="#6B7280" stroke-width="1.2" filter="url(#shadow)"/>
+  <text x="500" y="157" text-anchor="middle" font-family="Arial,Helvetica,sans-serif" font-size="12" font-weight="bold" fill="#1F2937">Jaeger / Tempo</text>
+
+  <text x="570" y="156" text-anchor="start" font-family="Arial,Helvetica,sans-serif" font-size="10" fill="#8B949E">spec.tracing config</text>
+</svg>

--- a/docs/model-serving/generative-inference/llmisvc/imgs/canary_routing_architecture.svg
+++ b/docs/model-serving/generative-inference/llmisvc/imgs/canary_routing_architecture.svg
@@ -1,0 +1,170 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="700" height="540" viewBox="0 0 700 540">
+  <defs>
+    <filter id="shadow" x="-5%" y="-5%" width="110%" height="120%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2" result="blur"/>
+      <feOffset dx="0" dy="1" result="shifted"/>
+      <feFlood flood-color="#000" flood-opacity="0.06" result="color"/>
+      <feComposite in="color" in2="shifted" operator="in" result="shadow"/>
+      <feMerge>
+        <feMergeNode in="shadow"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    <marker id="arr-amber" viewBox="0 0 10 10" refX="9" refY="5"
+            markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0,0 L10,5 L0,10z" fill="#D97706"/>
+    </marker>
+    <marker id="arr-blue" viewBox="0 0 10 10" refX="9" refY="5"
+            markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0,0 L10,5 L0,10z" fill="#4A7FBF"/>
+    </marker>
+    <marker id="arr-gray" viewBox="0 0 10 10" refX="9" refY="5"
+            markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0,0 L10,5 L0,10z" fill="#8B949E"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="700" height="540" fill="#F6F8FA" rx="4"/>
+
+  <!-- Group boundary -->
+  <rect x="38" y="105" width="624" height="260" rx="12"
+        fill="#F0F6FF" stroke="#4A7FBF" stroke-width="1.2" stroke-dasharray="6,4"/>
+  <text x="350" y="122" text-anchor="middle"
+        font-family="system-ui,Arial,sans-serif" font-size="11" font-weight="bold"
+        fill="#4A7FBF">group: my-model</text>
+
+  <!-- "owns" arrows (drawn early so boxes paint over crossings) -->
+
+  <!-- owns: LLMISvc v1 -> HTTPRoute v1 -->
+  <line x1="120" y1="438" x2="90" y2="252"
+        stroke="#8B949E" stroke-width="1.2" stroke-dasharray="5,3"
+        marker-end="url(#arr-gray)"/>
+  <text x="82" y="398"
+        font-family="system-ui,Arial,sans-serif" font-size="9" fill="#8B949E">owns</text>
+
+  <!-- owns: LLMISvc v1 -> Pool v1 -->
+  <line x1="220" y1="438" x2="215" y2="340"
+        stroke="#8B949E" stroke-width="1.2" stroke-dasharray="5,3"
+        marker-end="url(#arr-gray)"/>
+  <text x="224" y="398"
+        font-family="system-ui,Arial,sans-serif" font-size="9" fill="#8B949E">owns</text>
+
+  <!-- owns: LLMISvc v2 -> HTTPRoute v2 -->
+  <line x1="580" y1="438" x2="605" y2="252"
+        stroke="#8B949E" stroke-width="1.2" stroke-dasharray="5,3"
+        marker-end="url(#arr-gray)"/>
+  <text x="592" y="398"
+        font-family="system-ui,Arial,sans-serif" font-size="9" fill="#8B949E">owns</text>
+
+  <!-- owns: LLMISvc v2 -> Pool v2 -->
+  <line x1="480" y1="438" x2="485" y2="340"
+        stroke="#8B949E" stroke-width="1.2" stroke-dasharray="5,3"
+        marker-end="url(#arr-gray)"/>
+  <text x="466" y="398"
+        font-family="system-ui,Arial,sans-serif" font-size="9" fill="#8B949E">owns</text>
+
+  <!-- Gateway -->
+  <rect x="250" y="18" width="200" height="55" rx="8"
+        fill="#fff" stroke="#6B7280" stroke-width="1.2" filter="url(#shadow)"/>
+  <text x="350" y="40" text-anchor="middle"
+        font-family="system-ui,Arial,sans-serif" font-size="12" font-weight="bold"
+        fill="#1F2937">Gateway</text>
+  <text x="350" y="55" text-anchor="middle"
+        font-family="system-ui,Arial,sans-serif" font-size="10" fill="#6B7280">Picks oldest matching route</text>
+
+  <!-- HTTPRoute v1 (active) -->
+  <rect x="58" y="138" width="255" height="110" rx="8"
+        fill="#FAFCFF" stroke="#4A7FBF" stroke-width="1.8" filter="url(#shadow)"/>
+  <text x="185" y="158" text-anchor="middle"
+        font-family="system-ui,Arial,sans-serif" font-size="12" font-weight="bold"
+        fill="#1F2937">HTTPRoute (v1)</text>
+  <text x="185" y="172" text-anchor="middle"
+        font-family="system-ui,Arial,sans-serif" font-size="10" fill="#6B7280">active (oldest)</text>
+  <text x="75" y="194"
+        font-family="'Courier New',Courier,monospace" font-size="10" fill="#374151">backendRefs:</text>
+  <text x="75" y="210"
+        font-family="'Courier New',Courier,monospace" font-size="10" fill="#374151">  - v1-pool  weight: 9</text>
+  <text x="75" y="226"
+        font-family="'Courier New',Courier,monospace" font-size="10" fill="#374151">  - v2-pool  weight: 1</text>
+
+  <!-- HTTPRoute v2 (standby) -->
+  <rect x="387" y="138" width="255" height="110" rx="8"
+        fill="#fff" stroke="#4A7FBF" stroke-width="1.2" filter="url(#shadow)"/>
+  <text x="514" y="158" text-anchor="middle"
+        font-family="system-ui,Arial,sans-serif" font-size="12" font-weight="bold"
+        fill="#1F2937">HTTPRoute (v2)</text>
+  <text x="514" y="172" text-anchor="middle"
+        font-family="system-ui,Arial,sans-serif" font-size="10" fill="#6B7280">standby</text>
+  <text x="404" y="194"
+        font-family="'Courier New',Courier,monospace" font-size="10" fill="#374151">backendRefs:</text>
+  <text x="404" y="210"
+        font-family="'Courier New',Courier,monospace" font-size="10" fill="#374151">  - v1-pool  weight: 9</text>
+  <text x="404" y="226"
+        font-family="'Courier New',Courier,monospace" font-size="10" fill="#374151">  - v2-pool  weight: 1</text>
+
+  <!-- InferencePool v1 -->
+  <rect x="100" y="294" width="170" height="42" rx="8"
+        fill="#fff" stroke="#4A7FBF" stroke-width="1.2" filter="url(#shadow)"/>
+  <text x="185" y="319" text-anchor="middle"
+        font-family="system-ui,Arial,sans-serif" font-size="12" font-weight="bold"
+        fill="#1F2937">v1 InferencePool</text>
+
+  <!-- InferencePool v2 -->
+  <rect x="430" y="294" width="170" height="42" rx="8"
+        fill="#fff" stroke="#4A7FBF" stroke-width="1.2" filter="url(#shadow)"/>
+  <text x="515" y="319" text-anchor="middle"
+        font-family="system-ui,Arial,sans-serif" font-size="12" font-weight="bold"
+        fill="#1F2937">v2 InferencePool</text>
+
+  <!-- LLMInferenceService v1 -->
+  <rect x="80" y="438" width="200" height="62" rx="8"
+        fill="#F5F8FF" stroke="#4A7FBF" stroke-width="1.2" filter="url(#shadow)"/>
+  <text x="180" y="455" text-anchor="middle"
+        font-family="system-ui,Arial,sans-serif" font-size="10" fill="#4A7FBF">LLMInferenceService</text>
+  <text x="180" y="471" text-anchor="middle"
+        font-family="system-ui,Arial,sans-serif" font-size="12" font-weight="bold"
+        fill="#1F2937">my-model-v1</text>
+  <text x="180" y="486" text-anchor="middle"
+        font-family="system-ui,Arial,sans-serif" font-size="10" fill="#6B7280">weight: 9</text>
+
+  <!-- LLMInferenceService v2 -->
+  <rect x="420" y="438" width="200" height="62" rx="8"
+        fill="#F5F8FF" stroke="#4A7FBF" stroke-width="1.2" filter="url(#shadow)"/>
+  <text x="520" y="455" text-anchor="middle"
+        font-family="system-ui,Arial,sans-serif" font-size="10" fill="#4A7FBF">LLMInferenceService</text>
+  <text x="520" y="471" text-anchor="middle"
+        font-family="system-ui,Arial,sans-serif" font-size="12" font-weight="bold"
+        fill="#1F2937">my-model-v2</text>
+  <text x="520" y="486" text-anchor="middle"
+        font-family="system-ui,Arial,sans-serif" font-size="10" fill="#6B7280">weight: 1</text>
+
+  <!-- Amber arrow: Gateway -> HTTPRoute v1 (solid, active) -->
+  <line x1="305" y1="73" x2="185" y2="134"
+        stroke="#D97706" stroke-width="1.5" marker-end="url(#arr-amber)"/>
+
+  <!-- Amber arrow: Gateway -> HTTPRoute v2 (dashed, standby) -->
+  <line x1="395" y1="73" x2="514" y2="134"
+        stroke="#D97706" stroke-width="1.5" stroke-dasharray="6,4"
+        marker-end="url(#arr-amber)"/>
+
+  <!-- Blue arrow: HTTPRoute v1 -> v1 Pool (90%) -->
+  <line x1="155" y1="248" x2="165" y2="290"
+        stroke="#4A7FBF" stroke-width="1.5" marker-end="url(#arr-blue)"/>
+
+  <!-- Blue arrow: HTTPRoute v1 -> v2 Pool (10%) -->
+  <line x1="260" y1="248" x2="480" y2="290"
+        stroke="#4A7FBF" stroke-width="1.5" marker-end="url(#arr-blue)"/>
+
+  <!-- 90% badge -->
+  <rect x="126" y="260" width="36" height="18" rx="9" fill="#4A7FBF"/>
+  <text x="144" y="273" text-anchor="middle"
+        font-family="system-ui,Arial,sans-serif" font-size="10" font-weight="bold"
+        fill="#fff">90%</text>
+
+  <!-- 10% badge -->
+  <rect x="350" y="258" width="36" height="18" rx="9" fill="#4A7FBF"/>
+  <text x="368" y="271" text-anchor="middle"
+        font-family="system-ui,Arial,sans-serif" font-size="10" font-weight="bold"
+        fill="#fff">10%</text>
+</svg>

--- a/docs/model-serving/generative-inference/llmisvc/imgs/canary_traffic_progression.svg
+++ b/docs/model-serving/generative-inference/llmisvc/imgs/canary_traffic_progression.svg
@@ -1,0 +1,89 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="750" height="200" viewBox="0 0 750 200">
+  <defs>
+    <filter id="shadow" x="-5%" y="-5%" width="110%" height="120%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2" result="blur"/>
+      <feOffset dx="0" dy="1" result="shifted"/>
+      <feFlood flood-color="#000" flood-opacity="0.06" result="color"/>
+      <feComposite in="color" in2="shifted" operator="in" result="shadow"/>
+      <feMerge>
+        <feMergeNode in="shadow"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5"
+            markerWidth="6" markerHeight="6" orient="auto">
+      <path d="M0,1 L8,5 L0,9" fill="#9CA3AF" stroke="none"/>
+    </marker>
+    <clipPath id="c1"><rect x="30" y="50" width="105" height="82" rx="4"/></clipPath>
+    <clipPath id="c2"><rect x="175" y="50" width="105" height="82" rx="4"/></clipPath>
+    <clipPath id="c3"><rect x="320" y="50" width="105" height="82" rx="4"/></clipPath>
+    <clipPath id="c4"><rect x="465" y="50" width="105" height="82" rx="4"/></clipPath>
+    <clipPath id="c5"><rect x="610" y="50" width="105" height="82" rx="4"/></clipPath>
+  </defs>
+
+  <!-- Background -->
+  <rect width="750" height="200" fill="#F6F8FA" rx="4"/>
+
+  <!-- Stage 1: Deploy v1 -->
+  <text x="82" y="38" text-anchor="middle" font-family="Arial,Helvetica,sans-serif" font-size="12" font-weight="bold" fill="#1F2328">Deploy v1</text>
+  <rect x="30" y="50" width="105" height="82" rx="4" fill="#fff" stroke="#D0D7DE" stroke-width="0.75" filter="url(#shadow)"/>
+  <g clip-path="url(#c1)">
+    <rect x="30" y="50" width="105" height="82" fill="#4A7FBF"/>
+  </g>
+  <text x="82" y="95" text-anchor="middle" font-family="Arial,Helvetica,sans-serif" font-size="11" font-weight="bold" fill="#fff">v1: 100%</text>
+
+  <!-- Arrow 1-2 -->
+  <line x1="143" y1="91" x2="167" y2="91" stroke="#9CA3AF" stroke-width="1.2" marker-end="url(#arrow)"/>
+
+  <!-- Stage 2: Add v2 -->
+  <text x="227" y="38" text-anchor="middle" font-family="Arial,Helvetica,sans-serif" font-size="12" font-weight="bold" fill="#1F2328">Add v2</text>
+  <rect x="175" y="50" width="105" height="82" rx="4" fill="#fff" stroke="#D0D7DE" stroke-width="0.75" filter="url(#shadow)"/>
+  <g clip-path="url(#c2)">
+    <rect x="175" y="50" width="105" height="73.8" fill="#4A7FBF"/>
+    <rect x="175" y="123.8" width="105" height="8.2" fill="#2D8A56"/>
+  </g>
+  <text x="227" y="90" text-anchor="middle" font-family="Arial,Helvetica,sans-serif" font-size="11" font-weight="bold" fill="#fff">v1: 90%</text>
+  <text x="227" y="143" text-anchor="middle" font-family="Arial,Helvetica,sans-serif" font-size="9" fill="#2D8A56">v2: 10%</text>
+
+  <!-- Arrow 2-3 -->
+  <line x1="288" y1="91" x2="312" y2="91" stroke="#9CA3AF" stroke-width="1.2" marker-end="url(#arrow)"/>
+
+  <!-- Stage 3: Validate -->
+  <text x="372" y="38" text-anchor="middle" font-family="Arial,Helvetica,sans-serif" font-size="12" font-weight="bold" fill="#1F2328">Validate</text>
+  <rect x="320" y="50" width="105" height="82" rx="4" fill="#fff" stroke="#D0D7DE" stroke-width="0.75" filter="url(#shadow)"/>
+  <g clip-path="url(#c3)">
+    <rect x="320" y="50" width="105" height="41" fill="#4A7FBF"/>
+    <rect x="320" y="91" width="105" height="41" fill="#2D8A56"/>
+  </g>
+  <text x="372" y="75" text-anchor="middle" font-family="Arial,Helvetica,sans-serif" font-size="11" font-weight="bold" fill="#fff">v1: 50%</text>
+  <text x="372" y="116" text-anchor="middle" font-family="Arial,Helvetica,sans-serif" font-size="11" font-weight="bold" fill="#fff">v2: 50%</text>
+
+  <!-- Arrow 3-4 -->
+  <line x1="433" y1="91" x2="457" y2="91" stroke="#9CA3AF" stroke-width="1.2" marker-end="url(#arrow)"/>
+
+  <!-- Stage 4: Promote -->
+  <text x="517" y="38" text-anchor="middle" font-family="Arial,Helvetica,sans-serif" font-size="12" font-weight="bold" fill="#1F2328">Promote</text>
+  <rect x="465" y="50" width="105" height="82" rx="4" fill="#fff" stroke="#D0D7DE" stroke-width="0.75" filter="url(#shadow)"/>
+  <g clip-path="url(#c4)">
+    <rect x="465" y="50" width="105" height="82" fill="#2D8A56"/>
+  </g>
+  <text x="517" y="95" text-anchor="middle" font-family="Arial,Helvetica,sans-serif" font-size="11" font-weight="bold" fill="#fff">v2: 100%</text>
+
+  <!-- Arrow 4-5 -->
+  <line x1="578" y1="91" x2="602" y2="91" stroke="#9CA3AF" stroke-width="1.2" marker-end="url(#arrow)"/>
+
+  <!-- Stage 5: Cleanup -->
+  <text x="662" y="38" text-anchor="middle" font-family="Arial,Helvetica,sans-serif" font-size="12" font-weight="bold" fill="#1F2328">Cleanup</text>
+  <rect x="610" y="50" width="105" height="82" rx="4" fill="#fff" stroke="#D0D7DE" stroke-width="0.75" filter="url(#shadow)"/>
+  <g clip-path="url(#c5)">
+    <rect x="610" y="50" width="105" height="82" fill="#2D8A56"/>
+  </g>
+  <text x="662" y="95" text-anchor="middle" font-family="Arial,Helvetica,sans-serif" font-size="11" font-weight="bold" fill="#fff">v2: 100%</text>
+  <text x="662" y="147" text-anchor="middle" font-family="Arial,Helvetica,sans-serif" font-size="9" font-style="italic" fill="#9CA3AF">v1 stopped</text>
+
+  <!-- Legend -->
+  <rect x="620" y="170" width="10" height="10" rx="2" fill="#4A7FBF"/>
+  <text x="634" y="179" font-family="Arial,Helvetica,sans-serif" font-size="10" fill="#1F2328">v1</text>
+  <rect x="660" y="170" width="10" height="10" rx="2" fill="#2D8A56"/>
+  <text x="674" y="179" font-family="Arial,Helvetica,sans-serif" font-size="10" fill="#1F2328">v2</text>
+</svg>

--- a/docs/model-serving/generative-inference/llmisvc/llmisvc-configuration.md
+++ b/docs/model-serving/generative-inference/llmisvc/llmisvc-configuration.md
@@ -449,6 +449,42 @@ spec:
 
 ---
 
+### Traffic Splitting (Canary Rollout)
+
+Traffic splitting lets you run two or more versions of an LLMInferenceService side by side and shift live traffic between them. See the [Canary Rollout guide](./canary-rollout.md) for a full walkthrough.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `group` | `string` | No | Routing group name. All LLMISVCs with the same group participate in weighted traffic splitting. Members sharing the same `model.name` and LoRA adapter set participate in the same weighted split. |
+| `weight` | `int32` | No | Relative traffic share within the group (0-1,000,000). Traffic is distributed proportionally across all members' weights. A weight of `0` means the member is in the group but receives no traffic through shared model-routing paths. |
+
+```yaml
+spec:
+  router:
+    route:
+      group: my-model
+      weight: 9
+    scheduler: {}
+```
+
+**Validation rules:**
+
+| Spec | Valid? | Why |
+|------|--------|-----|
+| No `group`, no `weight` | Yes | Standard LLMISVC, no traffic splitting |
+| `weight` without `group` | No | Weight requires group |
+| `group` without `weight` | No | Group requires weight |
+| `group` + `weight` | Yes | Member joins the named group. Controller creates the HTTPRoute. |
+| `group` + `weight` + `route.http.refs` | No | Traffic splitting needs controller-managed routes, not user-managed refs |
+
+When `group` is set, the mutating webhook automatically adds a `serving.kserve.io/routing-group` label for discovery:
+
+```bash
+kubectl get llmisvc -l serving.kserve.io/routing-group=my-model
+```
+
+---
+
 ### Scheduler Configuration
 
 #### Managed Scheduler (Default)

--- a/docs/model-serving/generative-inference/llmisvc/llmisvc-status.md
+++ b/docs/model-serving/generative-inference/llmisvc/llmisvc-status.md
@@ -36,6 +36,9 @@ Ready (= WorkloadsReady ∧ RouterReady)
       └── SchedulerWorkloadReady                  (managed scheduler only)
 
 PresetsCombined                                   (independent gate, not part of Ready rollup)
+
+GroupReady                                        (independent, only with routing group)
+GroupDegraded                                     (independent, only when group has divergent members)
 ```
 
 ---
@@ -95,6 +98,65 @@ These roll up into `RouterReady`. When no gateway or HTTP route configuration is
 | `HTTPRoutesReady` | Router reconciler | All HTTPRoute resources created and accepted by their parent Gateways | HTTPRoute not created, not accepted, or ref invalid | Only when HTTP route is configured |
 | `InferencePoolReady` | Router reconciler | InferencePool resource created and ready | Pool not found, not ready, or waiting for Gateway | Only when managed scheduler is enabled |
 | `SchedulerWorkloadReady` | Scheduler reconciler | Endpoint Picker (EPP) scheduler Deployment has desired replicas | Scheduler pods not ready | Only when managed scheduler is enabled |
+
+### Group Conditions (Traffic Splitting)
+
+These conditions are **independent** - they do not roll up into `RouterReady` or `Ready`. A broken group does not prevent the resource from serving inference individually. They are only present when the LLMInferenceService is part of a [routing group](./canary-rollout.md).
+
+| Condition | Set By | True | False | Presence |
+|-----------|--------|------|-------|----------|
+| `GroupReady` | Group reconciler | This member's sub-group is participating in weighted traffic splitting | Deletion blocked - waiting for peers to remove backendRefs (`FinalizationPending`) | Only when `spec.router.route.group` is set |
+| `GroupDegraded` | Group reconciler | Group has members with different model names or LoRA adapter sets (`MemberDivergence`). Each sub-group continues serving independently. | - | Only when divergence detected |
+
+```
+Ready (= WorkloadsReady ∧ RouterReady)
+ ├── WorkloadsReady
+ └── RouterReady
+
+GroupReady                               (independent)
+GroupDegraded                            (independent)
+```
+
+When an LLMInferenceService is part of a routing group, `.status.router.group` contains the full group topology:
+
+```yaml
+status:
+  router:
+    group:
+      name: my-model
+      members:
+        - name: my-model-v1
+          weight: 9
+          backendRef:
+            group: inference.networking.k8s.io
+            kind: InferencePool
+            name: my-model-v1-inference-pool
+            port: 8000
+        - name: my-model-v2
+          weight: 1
+          backendRef:
+            group: inference.networking.k8s.io
+            kind: InferencePool
+            name: my-model-v2-inference-pool
+            port: 8000
+```
+
+A force-stopped member stays visible with its declared weight:
+
+```yaml
+        - name: my-model-v1
+          weight: 9
+          stopped: true
+          backendRef: ...
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `group.name` | `string` | The routing group name (matches `spec.router.route.group`) |
+| `group.members[].name` | `string` | The LLMInferenceService name |
+| `group.members[].weight` | `int32` | The member's declared weight from spec |
+| `group.members[].stopped` | `bool` | True when the member has the force-stop annotation |
+| `group.members[].backendRef` | `BackendObjectReference` | The resolved backend reference used in HTTPRoute weighted routing |
 
 ---
 

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -141,6 +141,14 @@ const sidebars: SidebarsConfig = {
                 "model-serving/generative-inference/llmisvc/llmisvc-dependencies",
                 "model-serving/generative-inference/llmisvc/llmisvc-envoy-ai-gateway",
                 "model-serving/generative-inference/llmisvc/llmisvc-status",
+                {
+                  type: 'category',
+                  label: 'Traffic Management',
+                  items: [
+                    "model-serving/generative-inference/llmisvc/canary-rollout",
+                    "model-serving/generative-inference/llmisvc/canary-rollout-observability",
+                  ],
+                },
                 "model-serving/generative-inference/llmisvc/autoscaling/llmisvc-autoscaling",
                 "model-serving/generative-inference/llmisvc/autoscaling/llmisvc-autoscaling-examples",
               ],


### PR DESCRIPTION
## What

Adds canary rollout documentation for LLMInferenceService - a guided walkthrough for progressive traffic shifting during model upgrades, runtime changes, and configuration updates.

Two new pages under **LLMInferenceService > Traffic Management**:

- **Canary Rollout** - how groups and weights work, the rollout lifecycle (deploy, shift, validate, promote, rollback), step-by-step guide with YAML examples and kubectl commands, direct version access, and publisher path routing
- **Canary Rollout Observability** - per-version metrics setup (vLLM PodMonitor with `llm_isvc_name` relabeling, EPP ServiceMonitor), PromQL queries for comparing TTFT, throughput, error rate, KV cache, and queue depth between versions, and distributed tracing via `spec.tracing`

Includes SVG diagrams that visualize the routing architecture, traffic progression through rollout stages, and observability channels.

Reference updates add the `group`/`weight` traffic splitting fields to the configuration page and `GroupReady`/`GroupDegraded` conditions to the status reference.

## Why

Runtime upgrades and model rotations on LLM inference workloads are all-or-nothing today. There's no way to validate a change on a fraction of production traffic before committing. This documentation covers the traffic splitting primitive that ships with the controlled deployment feature ([kserve/kserve#5725](https://github.com/kserve/kserve/issues/5725)).

## References

- Upstream issue: [kserve/kserve#5725](https://github.com/kserve/kserve/issues/5725)
- API surface PR: [kserve/kserve#5727](https://github.com/kserve/kserve/pull/5727)
- Tracing PR: [kserve/kserve#5481](https://github.com/kserve/kserve/pull/5481)