### PR TITLE
docs: wrap mutually exclusive field notes in tip admonitions

### DIFF
--- a/docs/model-serving/generative-inference/llmisvc/llmisvc-configuration.md
+++ b/docs/model-serving/generative-inference/llmisvc/llmisvc-configuration.md
@@ -392,7 +392,9 @@ spec:
                   port: 8000
 ```
 
+:::tip
 `spec` and `refs` are mutually exclusive - use `refs` to bring your own HTTPRoute, or `spec` to have the controller create one with your custom rules.
+:::
 
 #### Real-world Use Cases
 
@@ -528,7 +530,9 @@ spec:
           targetPort: 8000
 ```
 
+:::tip
 `pool.spec` and `pool.ref` are mutually exclusive - use `ref` to bring your own InferencePool, or `spec` to have the controller create one with custom settings.
+:::
 ---
 
 ## Parallelism Specification

--- a/versioned_docs/version-0.19/model-serving/generative-inference/llmisvc/llmisvc-configuration.md
+++ b/versioned_docs/version-0.19/model-serving/generative-inference/llmisvc/llmisvc-configuration.md
@@ -392,7 +392,9 @@ spec:
                   port: 8000
 ```
 
+:::tip
 `spec` and `refs` are mutually exclusive - use `refs` to bring your own HTTPRoute, or `spec` to have the controller create one with your custom rules.
+:::
 
 #### Real-world Use Cases
 
@@ -492,7 +494,9 @@ spec:
           targetPort: 8000
 ```
 
+:::tip
 `pool.spec` and `pool.ref` are mutually exclusive - use `ref` to bring your own InferencePool, or `spec` to have the controller create one with custom settings.
+:::
 ---
 
 ## Parallelism Specification


### PR DESCRIPTION
## Summary

- Wraps "mutually exclusive" notes for `pool.spec`/`pool.ref` and `spec`/`refs` fields in Docusaurus `:::tip` admonitions
- These notes were rendering as headings due to adjacent `---` markdown separators, making them visually misleading
- Consistent with the existing `spec.scaling`/`spec.replicas` tip on the same page