### PR TITLE
docs: fix LLMInferenceServiceConfig verification namespace

### DIFF
--- a/versioned_docs/version-0.20/install/upgrade-guide.md
+++ b/versioned_docs/version-0.20/install/upgrade-guide.md
@@ -245,7 +245,7 @@ kubectl get pods -n kserve
 kubectl get clusterservingruntime
 
 # Verify LLMIsvcConfigs (if using LLMIsvc)
-kubectl get llminferenceserviceconfigs
+kubectl get llminferenceserviceconfigs -n kserve
 ```
 
 ## Getting Help


### PR DESCRIPTION
## Summary

Fix the verification command for LLMInferenceServiceConfig resources.

`LLMInferenceServiceConfig` is namespaced and the upgrade guide installs it in
the `kserve` namespace. Without `-n kserve`, the command queries the current
namespace (often `default`) and incorrectly returns no resources.

## Proposed Changes

- Add `-n kserve` to the `kubectl get llminferenceserviceconfigs` verification command.

## Validation

Verified after upgrading to KServe v0.20.0: the command lists the
LLMInferenceServiceConfig resources in the `kserve` namespace.