### PR TITLE
docs: document the logAllResponses inference logger option

### DIFF
--- a/docs/model-serving/predictive-inference/logger/index.md
+++ b/docs/model-serving/predictive-inference/logger/index.md
@@ -24,5 +24,6 @@ KServe offers several configurations for logging inference data:
 3. [TLS Enabled Logger](./tls-logger.md) - Secure your logs with TLS encryption
 4. [Payload Logger with Knative Eventing](./knative-eventing-logger.md) - Log through Knative Eventing infrastructure
 5. [Store Logs in Blob Storage](./blob-storage-logger.md) - Store logs in cloud blob storage
+6. [Log All Responses](./log-all-responses.md) - Log responses regardless of their status code
 
 Each configuration has its own use cases, advantages, and requirements. Choose the most suitable one based on your specific needs.

--- a/docs/model-serving/predictive-inference/logger/log-all-responses.md
+++ b/docs/model-serving/predictive-inference/logger/log-all-responses.md
@@ -1,0 +1,62 @@
+---
+title: Log All Responses
+description: "Log inference responses regardless of their status code in KServe"
+---
+
+# Log All Responses
+
+By default the inference logger only emits a response CloudEvent when the predictor returns `200 OK`. Responses with any other status code are not logged, so a request that was rejected leaves no trace beyond its request event.
+
+Setting `logAllResponses` to `true` logs the response regardless of its status code, and adds the status code to the response CloudEvent as the extension attribute `statuscode`.
+
+This is useful when the response body carries the reason a call was rejected: a `422` from a model that validates its input usually explains exactly what the caller got wrong.
+
+## Prerequisites
+- A Kubernetes cluster with [KServe installed](../../../getting-started/quickstart-guide.md).
+- Have familiarity with [KServe Inference Logger](./basic-logger.md).
+
+## Configuration
+
+```yaml
+apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  name: sklearn-iris
+spec:
+  predictor:
+    logger:
+      mode: all
+      url: http://message-dumper.default/
+      logAllResponses: true
+    model:
+      modelFormat:
+        name: sklearn
+      storageUri: gs://kfserving-examples/models/sklearn/1.0/model
+```
+
+## Effect on logged events
+
+With `logAllResponses` enabled, a request rejected by the predictor produces both a request and a response CloudEvent, and the response event carries the status code:
+
+```
+Context Attributes,
+  specversion: 1.0
+  type: org.kubeflow.serving.inference.response
+  source: http://localhost:9081/
+  id: 0d3d1b3a-1d0b-4b6f-9a49-4b0d6f6c9e57
+  time: 2025-01-15T10:32:11.472Z
+Extensions,
+  endpoint: default
+  inferenceservicename: sklearn-iris
+  namespace: default
+  statuscode: 422
+Data,
+  {"error":"Failed to process request: unexpected feature count"}
+```
+
+## Notes
+
+- The setting is opt-in. When it is unset, response events keep exactly the shape they have today and are still only emitted for `200` responses.
+- `mode` and `logAllResponses` control different things: `mode` decides which events are emitted at all, while `logAllResponses` decides which status codes produce a response event. With `mode: request` no response event is produced in the first place, so `logAllResponses` has no effect.
+- Because the filter is on the status code rather than on failure specifically, enabling this also logs other non-`200` success codes such as `201` and `204`. A `204 No Content` response has no body by definition, so its event carries an empty payload.
+- Enabling it increases the number of events emitted for services that return non-`200` responses frequently.

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -282,6 +282,7 @@ const sidebars: SidebarsConfig = {
                 "model-serving/predictive-inference/logger/tls-logger",
                 "model-serving/predictive-inference/logger/knative-eventing-logger",
                 "model-serving/predictive-inference/logger/blob-storage-logger",
+                "model-serving/predictive-inference/logger/log-all-responses",
               ]
             },
             {


### PR DESCRIPTION
Documents the `logAllResponses` opt-in added in kserve/kserve#6036 (issue kserve/kserve#2722).

By default the inference logger only emits a response CloudEvent for `200 OK`, so a rejected request leaves no trace beyond its request event. The new field logs the response regardless of status and adds a `statuscode` extension attribute.

Adds a new page under the Inference Logger section, modelled on the existing `Request Header Metadata Logger` page since the feature follows the same shape, and registers it in the section index and the sidebar. `versioned_sidebars/` is untouched — the feature is not in a release yet. `docs/reference/crd-api.mdx` is generated by `hack/crd-ref-docs`, so the new field will appear there when it is next regenerated.

The Notes section calls out three things that are easy to get wrong: `mode` and `logAllResponses` control different things (with `mode: request` there is no response event to log at all), the filter is on status code rather than on failure so `201`/`204` are logged too, and enabling it increases event volume.

Verified with `npm run docusaurus build` on Node 22.14 (matching CI): exit 0, no errors, no broken links. The page renders and appears in the sidebar. The one build warning is a set of pre-existing broken anchors in the versioned 0.16 docs, unrelated to this change.

Note: the example CloudEvent in the page uses illustrative values for `id`, `time` and the error message; the attribute set and format are what the implementation actually emits.
